### PR TITLE
Some probably non-ideal packaging changes to allow us to build

### DIFF
--- a/configure
+++ b/configure
@@ -6,6 +6,7 @@
 #
 #
 # Copyright (C) 1992-1996, 1998-2012 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp. 
 #
 #
 # This configure script is free software; the Free Software Foundation
@@ -885,6 +886,7 @@ exec_prefix=NONE
 no_create=
 no_recursion=
 prefix=NONE
+staging_prefix=NONE
 program_prefix=NONE
 program_suffix=NONE
 program_transform_name=s,x,x,
@@ -901,6 +903,13 @@ x_libraries=NONE
 # by default will actually change.
 # Use braces instead of parens because sh, perl, etc. also accept them.
 # (The list follows the same order as the GNU Coding Standards.)
+
+#if [ -z "$staging_prefix" ]; then 
+#	installdir='${prefix}'
+#else
+#	installdir='${staging_prefix}'
+#fi
+
 bindir='${exec_prefix}/bin'
 sbindir='${exec_prefix}/sbin'
 libexecdir='${exec_prefix}/libexec'
@@ -1188,6 +1197,13 @@ do
   -srcdir=* | --srcdir=* | --srcdi=* | --srcd=* | --src=* | --sr=*)
     srcdir=$ac_optarg ;;
 
+  -staging-prefix | --staging_prefix | --staging-prefix | --staging-prefi \
+  | --staging-pref | --staging-pre | --staging-pr | --staging-p | --staging-)
+    staging_prefix=staging_prefix ;;
+  -staging-prefix=* | --staging_prefix=* | --staging-prefix=* | --staging-prefi=* \
+  | --staging-pref=* | --staging-pre=* | --staging-pr=* | --staging-p=* | --staging-=*)
+    staging_prefix=$ac_optarg ;;
+ 
   -sysconfdir | --sysconfdir | --sysconfdi | --sysconfd | --sysconf \
   | --syscon | --sysco | --sysc | --sys | --sy)
     ac_prev=sysconfdir ;;
@@ -1298,7 +1314,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir
+		libdir localedir mandir staging_prefix
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -18301,6 +18317,7 @@ This config.status script is free software; the Free Software Foundation
 gives unlimited permission to copy, distribute and modify it."
 
 ac_pwd='$ac_pwd'
+installdir='$staging_prefix'
 srcdir='$srcdir'
 INSTALL='$INSTALL'
 MKDIR_P='$MKDIR_P'
@@ -19304,6 +19321,7 @@ s&@top_build_prefix@&$ac_top_build_prefix&;t t
 s&@srcdir@&$ac_srcdir&;t t
 s&@abs_srcdir@&$ac_abs_srcdir&;t t
 s&@top_srcdir@&$ac_top_srcdir&;t t
+s&@installdir@&$installdir&;t t
 s&@abs_top_srcdir@&$ac_abs_top_srcdir&;t t
 s&@builddir@&$ac_builddir&;t t
 s&@abs_builddir@&$ac_abs_builddir&;t t

--- a/src/client/beboot/Makefile.am
+++ b/src/client/beboot/Makefile.am
@@ -1,7 +1,7 @@
 pkglibexec_PROGRAMS = spindle_bootstrap
 
 spindle_bootstrap_LDFLAGS = -all-static $(AM_LDFLAGS)
-spindle_bootstrap_CPPFLAGS = $(AM_CPPFLAGS) -DLIBEXECDIR=\"$(pkglibexecdir)\" -DPROGLIBDIR=\"$(pkglibdir)\" -I$(top_srcdir)/../include -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/client
+spindle_bootstrap_CPPFLAGS = $(AM_CPPFLAGS) -DLIBEXECDIR=\"$(installdir)/libexec\" -DPROGLIBDIR=\"$(installdir)/lib\" -I$(top_srcdir)/../include -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/client
 spindle_bootstrap_LDADD = $(top_builddir)/logging/libspindlelogc.la 
 spindle_bootstrap_SOURCES = spindle_bootstrap.c $(top_srcdir)/../utils/parseloc.c $(top_srcdir)/../utils/spindle_mkdir.c $(top_srcdir)/client/exec_util.c
 

--- a/src/client/beboot/Makefile.in
+++ b/src/client/beboot/Makefile.in
@@ -2,6 +2,7 @@
 # @configure_input@
 
 # Copyright (C) 1994-2013 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 
 # This Makefile.in is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -299,8 +300,9 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+installdir = @installdir@
 spindle_bootstrap_LDFLAGS = -all-static $(AM_LDFLAGS)
-spindle_bootstrap_CPPFLAGS = $(AM_CPPFLAGS) -DLIBEXECDIR=\"$(pkglibexecdir)\" -DPROGLIBDIR=\"$(pkglibdir)\" -I$(top_srcdir)/../include -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/client
+spindle_bootstrap_CPPFLAGS = $(AM_CPPFLAGS) -DLIBEXECDIR=\"$(installdir)/libexec/spindle\" -DPROGLIBDIR=\"$(installdir)/lib/spindle\" -I$(top_srcdir)/../include -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/client
 spindle_bootstrap_LDADD = $(top_builddir)/logging/libspindlelogc.la \
 	$(am__append_1) $(am__append_2)
 spindle_bootstrap_SOURCES = spindle_bootstrap.c $(top_srcdir)/../utils/parseloc.c $(top_srcdir)/../utils/spindle_mkdir.c $(top_srcdir)/client/exec_util.c

--- a/src/client/configure
+++ b/src/client/configure
@@ -6,6 +6,7 @@
 #
 #
 # Copyright (C) 1992-1996, 1998-2012 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 #
 #
 # This configure script is free software; the Free Software Foundation
@@ -14,6 +15,7 @@
 ## M4sh Initialization. ##
 ## -------------------- ##
 
+echo $* > /tmp/DAVE_SOLT_CONFIG
 # Be more Bourne compatible
 DUALCASE=1; export DUALCASE # for MKS sh
 if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then :
@@ -766,6 +768,7 @@ bindir
 program_transform_name
 prefix
 exec_prefix
+staging_prefix
 PACKAGE_URL
 PACKAGE_BUGREPORT
 PACKAGE_STRING
@@ -830,6 +833,7 @@ exec_prefix=NONE
 no_create=
 no_recursion=
 prefix=NONE
+staging_prefix=NONE
 program_prefix=NONE
 program_suffix=NONE
 program_transform_name=s,x,x,
@@ -846,6 +850,7 @@ x_libraries=NONE
 # by default will actually change.
 # Use braces instead of parens because sh, perl, etc. also accept them.
 # (The list follows the same order as the GNU Coding Standards.)
+
 bindir='${exec_prefix}/bin'
 sbindir='${exec_prefix}/sbin'
 libexecdir='${exec_prefix}/libexec'
@@ -971,6 +976,12 @@ do
   | --exec-pref=* | --exec-pre=* | --exec-pr=* | --exec-p=* | --exec-=* \
   | --exec=* | --exe=* | --ex=*)
     exec_prefix=$ac_optarg ;;
+  -staging-prefix | --staging_prefix | --staging-prefix | --staging-prefi \
+  | --staging-pref | --staging-pre | --staging-pr | --staging-p | --staging-) 
+    staging_prefix=staging_prefix ;;
+  -staging-prefix=* | --staging_prefix=* | --staging-prefix=* | --staging-prefi=* \
+  | --staging-pref=* | --staging-pre=* | --staging-pr=* | --staging-p=* | --staging-=*)
+    staging_prefix=$ac_optarg ;;
 
   -gas | --gas | --ga | --g)
     # Obsolete; use --with-gas.
@@ -13432,6 +13443,7 @@ gives unlimited permission to copy, distribute and modify it."
 
 ac_pwd='$ac_pwd'
 srcdir='$srcdir'
+installdir='$staging_prefix'
 INSTALL='$INSTALL'
 MKDIR_P='$MKDIR_P'
 AWK='$AWK'
@@ -14342,6 +14354,7 @@ s|@configure_input@|$ac_sed_conf_input|;t t
 s&@top_builddir@&$ac_top_builddir_sub&;t t
 s&@top_build_prefix@&$ac_top_build_prefix&;t t
 s&@srcdir@&$ac_srcdir&;t t
+s&@installdir@&$installdir&;t t
 s&@abs_srcdir@&$ac_abs_srcdir&;t t
 s&@top_srcdir@&$ac_top_srcdir&;t t
 s&@abs_top_srcdir@&$ac_abs_top_srcdir&;t t

--- a/src/client/ldsolookup/Makefile.am
+++ b/src/client/ldsolookup/Makefile.am
@@ -4,7 +4,7 @@ pkglib_LTLIBRARIES = libprint_ldso_audit.la
 print_ldso_entry_SOURCES = print_ldso_entry.c
 libprint_ldso_audit_la_SOURCES = print_ldso_audit.c
 
-print_ldso_entry_CPPFLAGS = -DLIBEXECDIR=\"$(pkglibexecdir)\"
+print_ldso_entry_CPPFLAGS = -DLIBEXECDIR=\"$(installlibexecdir)\"
 
 libprint_ldso_audit_la_LDFLAGS = -shared -avoid-version
 

--- a/src/client/ldsolookup/Makefile.in
+++ b/src/client/ldsolookup/Makefile.in
@@ -2,6 +2,7 @@
 # @configure_input@
 
 # Copyright (C) 1994-2013 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 
 # This Makefile.in is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -331,10 +332,12 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+installdir = @installdir@
+
 pkglib_LTLIBRARIES = libprint_ldso_audit.la
 print_ldso_entry_SOURCES = print_ldso_entry.c
 libprint_ldso_audit_la_SOURCES = print_ldso_audit.c
-print_ldso_entry_CPPFLAGS = -DLIBEXECDIR=\"$(pkglibexecdir)\"
+print_ldso_entry_CPPFLAGS = -DLIBEXECDIR=\"$(installdir)/libexec/spindle/\"
 libprint_ldso_audit_la_LDFLAGS = -shared -avoid-version
 @BGQ_BLD_TRUE@print_ldso_entry_LDFLAGS = -dynamic
 all: all-am

--- a/src/client/logging/Makefile.in
+++ b/src/client/logging/Makefile.in
@@ -2,6 +2,7 @@
 # @configure_input@
 
 # Copyright (C) 1994-2013 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 
 # This Makefile.in is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -290,11 +291,12 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+installdir = @installdir@
 noinst_LTLIBRARIES = libspindlelogc.la
 AM_CFLAGS = -fvisibility=hidden
 libspindlelogc_la_SOURCES = $(top_srcdir)/../logging/spindle_logc.c $(top_srcdir)/../utils/spindle_mkdir.c
 libspindlelogc_la_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -DSPINDLECLIENT
-libspindlelogc_la_CFLAGS = -DLIBEXEC=${pkglibexecdir} -DDAEMON_NAME=spindled_logd $(AM_CFLAGS)
+libspindlelogc_la_CFLAGS = -DLIBEXEC=${installdir}/libexec/spindle -DDAEMON_NAME=spindled_logd $(AM_CFLAGS)
 all: all-am
 
 .SUFFIXES:

--- a/src/fe/configure
+++ b/src/fe/configure
@@ -6,6 +6,7 @@
 #
 #
 # Copyright (C) 1992-1996, 1998-2012 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 #
 #
 # This configure script is free software; the Free Software Foundation
@@ -787,6 +788,7 @@ bindir
 program_transform_name
 prefix
 exec_prefix
+staging_prefix
 PACKAGE_URL
 PACKAGE_BUGREPORT
 PACKAGE_STRING
@@ -862,6 +864,7 @@ exec_prefix=NONE
 no_create=
 no_recursion=
 prefix=NONE
+staging_prefix=NONE
 program_prefix=NONE
 program_suffix=NONE
 program_transform_name=s,x,x,
@@ -878,6 +881,15 @@ x_libraries=NONE
 # by default will actually change.
 # Use braces instead of parens because sh, perl, etc. also accept them.
 # (The list follows the same order as the GNU Coding Standards.)
+
+if [ -z "$staging_prefix" ]; then
+        installlibdir='${prefix}/libdir}'
+        installlibexecdir='${prefix}/libexec}'
+else
+        installlibdir='${staging_prefix}/lib}'
+        installlibexecdir='${staging_prefix}/libexec}'
+fi
+
 bindir='${exec_prefix}/bin'
 sbindir='${exec_prefix}/sbin'
 libexecdir='${exec_prefix}/libexec'
@@ -1003,6 +1015,12 @@ do
   | --exec-pref=* | --exec-pre=* | --exec-pr=* | --exec-p=* | --exec-=* \
   | --exec=* | --exe=* | --ex=*)
     exec_prefix=$ac_optarg ;;
+  -staging-prefix | --staging_prefix | --staging-prefix | --staging-prefi \
+  | --staging-pref | --staging-pre | --staging-pr | --staging-p | --staging-)
+    staging_prefix=staging_prefix ;;
+  -staging-prefix=* | --staging_prefix=* | --staging-prefix=* | --staging-prefi=* \
+  | --staging-pref=* | --staging-pre=* | --staging-pr=* | --staging-p=* | --staging-=*)
+    staging_prefix=$ac_optarg ;;
 
   -gas | --gas | --ga | --g)
     # Obsolete; use --with-gas.
@@ -17801,6 +17819,7 @@ This config.status script is free software; the Free Software Foundation
 gives unlimited permission to copy, distribute and modify it."
 
 ac_pwd='$ac_pwd'
+installdir='$staging_prefix'
 srcdir='$srcdir'
 INSTALL='$INSTALL'
 MKDIR_P='$MKDIR_P'
@@ -18807,6 +18826,7 @@ s|@configure_input@|$ac_sed_conf_input|;t t
 s&@top_builddir@&$ac_top_builddir_sub&;t t
 s&@top_build_prefix@&$ac_top_build_prefix&;t t
 s&@srcdir@&$ac_srcdir&;t t
+s&@installdir@&$installdir&;t t
 s&@abs_srcdir@&$ac_abs_srcdir&;t t
 s&@top_srcdir@&$ac_top_srcdir&;t t
 s&@abs_top_srcdir@&$ac_abs_top_srcdir&;t t

--- a/src/fe/hostbin/Makefile.in
+++ b/src/fe/hostbin/Makefile.in
@@ -2,6 +2,7 @@
 # @configure_input@
 
 # Copyright (C) 1994-2013 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 
 # This Makefile.in is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -301,9 +302,10 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+installdir = @installdir@
 noinst_LTLIBRARIES = libhostbin.la
 libhostbin_la_SOURCES = launch_hostbin.cc
-libhostbin_la_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -DLIBEXEC=\"${pkglibexecdir}\"
+libhostbin_la_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -DLIBEXEC=\"${installdir}/libexec\"
 all: all-am
 
 .SUFFIXES:

--- a/src/fe/launchmon/Makefile.am
+++ b/src/fe/launchmon/Makefile.am
@@ -1,6 +1,6 @@
 noinst_LTLIBRARIES = libfelmon.la
 
 libfelmon_la_SOURCES = spindle_fe_lmon.cc
-libfelmon_la_CPPFLAGS = $(LAUNCHMON_INC) -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -DBINDIR=\"$(pkglibexecdir)\" -DLIBEXECDIR=\"$(pkglibexecdir)\"
+libfelmon_la_CPPFLAGS = $(LAUNCHMON_INC) -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -DBINDIR=\"$(installlibexecdir)\" -DLIBEXECDIR=\"$(installlibexecdir)\"
 libfelmon_la_LIBADD = $(LAUNCHMON_LIB) $(LAUNCHMON_RMCOMM) -lmonfeapi
 

--- a/src/fe/launchmon/Makefile.in
+++ b/src/fe/launchmon/Makefile.in
@@ -2,6 +2,7 @@
 # @configure_input@
 
 # Copyright (C) 1994-2013 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 
 # This Makefile.in is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -303,9 +304,10 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+installdir = @installdir@
 noinst_LTLIBRARIES = libfelmon.la
 libfelmon_la_SOURCES = spindle_fe_lmon.cc
-libfelmon_la_CPPFLAGS = $(LAUNCHMON_INC) -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -DBINDIR=\"$(pkglibexecdir)\" -DLIBEXECDIR=\"$(pkglibexecdir)\"
+libfelmon_la_CPPFLAGS = $(LAUNCHMON_INC) -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -DBINDIR=\"$(installdir)/bin\" -DLIBEXECDIR=\"$(installdir)/libexec/spindle/\"
 libfelmon_la_LIBADD = $(LAUNCHMON_LIB) $(LAUNCHMON_RMCOMM) -lmonfeapi
 all: all-am
 

--- a/src/fe/logging/Makefile.in
+++ b/src/fe/logging/Makefile.in
@@ -2,6 +2,7 @@
 # @configure_input@
 
 # Copyright (C) 1994-2013 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 
 # This Makefile.in is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -331,13 +332,14 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+installdir = @installdir@
 noinst_LTLIBRARIES = libspindlelogc.la
 spindlef_logd_SOURCES = $(top_srcdir)/../logging/spindle_logd.cc
 spindlef_logd_CPPFLAGS = -I$(top_srcdir)/../logging
 spindlef_logd_LDADD = -lpthread
 libspindlelogc_la_SOURCES = $(top_srcdir)/../logging/spindle_logc.c $(top_srcdir)/../utils/spindle_mkdir.c
 libspindlelogc_la_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../utils -I$(top_srcdir)/../include
-libspindlelogc_la_CFLAGS = -DLIBEXEC=${pkglibexecdir} -DDAEMON_NAME=spindlef_logd
+libspindlelogc_la_CFLAGS = -DLIBEXEC=${installdir}/libexec -DDAEMON_NAME=spindlef_logd
 all: all-am
 
 .SUFFIXES:

--- a/src/fe/openmpi_intercept/Makefile.am
+++ b/src/fe/openmpi_intercept/Makefile.am
@@ -7,4 +7,4 @@ libompiintercept_la_LDFLAGS = -shared -avoid-version
 libparseompi_la_SOURCES = parse_openmpi.cc
 
 AM_CPPFLAGS = -I$(top_srcdir)/../include -I$(top_srcdir)/../logging -I$(top_srcdir)/startup
-libparseompi_la_CPPFLAGS  = $(AM_CPPFLAGS) -DLIBEXECDIR=\"$(pkglibexecdir)\" -DPROGLIBDIR=\"$(pkglibdir)\"
+libparseompi_la_CPPFLAGS  = $(AM_CPPFLAGS) -DLIBEXECDIR=\"$(installlibexecdir)\" -DPROGLIBDIR=\"$(pkglibdir)\"

--- a/src/fe/openmpi_intercept/Makefile.in
+++ b/src/fe/openmpi_intercept/Makefile.in
@@ -2,6 +2,7 @@
 # @configure_input@
 
 # Copyright (C) 1994-2013 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 
 # This Makefile.in is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -355,13 +356,14 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+installdir = @installdir@
 pkglib_LTLIBRARIES = libompiintercept.la
 noinst_LTLIBRARIES = libparseompi.la
 libompiintercept_la_SOURCES = ompi_intercept.c
 libompiintercept_la_LDFLAGS = -shared -avoid-version
 libparseompi_la_SOURCES = parse_openmpi.cc
 AM_CPPFLAGS = -I$(top_srcdir)/../include -I$(top_srcdir)/../logging -I$(top_srcdir)/startup
-libparseompi_la_CPPFLAGS = $(AM_CPPFLAGS) -DLIBEXECDIR=\"$(pkglibexecdir)\" -DPROGLIBDIR=\"$(pkglibdir)\"
+libparseompi_la_CPPFLAGS = $(AM_CPPFLAGS) -DLIBEXECDIR=\"$(installdir)/libexec/spindle\" -DPROGLIBDIR=\"$(installdir)/lib\"
 all: all-am
 
 .SUFFIXES:

--- a/src/fe/startup/Makefile.am
+++ b/src/fe/startup/Makefile.am
@@ -5,7 +5,7 @@ include_HEADERS = $(top_srcdir)/../include/spindle_launch.h
 AM_CPPFLAGS = -I$(top_srcdir)/../logging
 
 CORE_SOURCES = spindle_fe.cc parseargs.cc parse_preload.cc $(top_srcdir)/../utils/pathfn.c $(top_srcdir)/../utils/keyfile.c $(top_srcdir)/../utils/parseloc.c
-CORE_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/../include -I$(top_srcdir)/comlib -I$(top_srcdir)/../server/cache -I$(top_srcdir)/../server/comlib -I$(top_srcdir)/../utils -I$(top_srcdir)/../cobo -DBINDIR=\"$(pkglibexecdir)\" -DLIBEXECDIR=\"$(pkglibexecdir)\" -DPROGLIBDIR=\"$(pkglibdir)\"
+CORE_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/../include -I$(top_srcdir)/comlib -I$(top_srcdir)/../server/cache -I$(top_srcdir)/../server/comlib -I$(top_srcdir)/../utils -I$(top_srcdir)/../cobo -DBINDIR=\"$(installlibexecdir)\" -DLIBEXECDIR=\"$(installlibexecdir)\" -DPROGLIBDIR=\"$(installlibdir)\"
 CORE_LDADD = $(top_builddir)/logging/libspindlelogc.la -lpthread
 if COBO
 CORE_LDADD += $(top_builddir)/comlib/libfe_cobo.la $(top_builddir)/cobo/libldcs_cobo.la

--- a/src/fe/startup/Makefile.in
+++ b/src/fe/startup/Makefile.in
@@ -2,6 +2,7 @@
 # @configure_input@
 
 # Copyright (C) 1994-2013 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 
 # This Makefile.in is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -380,11 +381,12 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+installdir = @installdir@
 lib_LTLIBRARIES = libspindlefe.la
 include_HEADERS = $(top_srcdir)/../include/spindle_launch.h
 AM_CPPFLAGS = -I$(top_srcdir)/../logging
 CORE_SOURCES = spindle_fe.cc parseargs.cc parse_preload.cc $(top_srcdir)/../utils/pathfn.c $(top_srcdir)/../utils/keyfile.c $(top_srcdir)/../utils/parseloc.c
-CORE_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/../include -I$(top_srcdir)/comlib -I$(top_srcdir)/../server/cache -I$(top_srcdir)/../server/comlib -I$(top_srcdir)/../utils -I$(top_srcdir)/../cobo -DBINDIR=\"$(pkglibexecdir)\" -DLIBEXECDIR=\"$(pkglibexecdir)\" -DPROGLIBDIR=\"$(pkglibdir)\"
+CORE_CPPFLAGS = $(AM_CPPFLAGS) -I$(top_srcdir)/../include -I$(top_srcdir)/comlib -I$(top_srcdir)/../server/cache -I$(top_srcdir)/../server/comlib -I$(top_srcdir)/../utils -I$(top_srcdir)/../cobo -DBINDIR=\"$(installdir)/bin\" -DLIBEXECDIR=\"$(installdir)/libexec/spindle\" -DPROGLIBDIR=\"$(installdir)/lib\"
 CORE_LDADD = $(top_builddir)/logging/libspindlelogc.la -lpthread \
 	$(am__append_1) $(am__append_2) $(MUNGE_DYN_LIB) \
 	$(GCRYPT_LIBS)

--- a/src/server/auditserver/Makefile.am
+++ b/src/server/auditserver/Makefile.am
@@ -1,7 +1,7 @@
 #noinst_LTLIBRARIES = libaudit_server_msocket.la libaudit_server_cobo.la libserverbase.la
 noinst_LTLIBRARIES = libaudit_server_cobo.la libserverbase.la
 
-AM_CPPFLAGS = -I$(top_srcdir)/comlib -I$(top_srcdir)/cache -I$(top_srcdir)/../cobo -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/../utils -DLIBEXECDIR=\"$(pkglibexecdir)\"
+AM_CPPFLAGS = -I$(top_srcdir)/comlib -I$(top_srcdir)/cache -I$(top_srcdir)/../cobo -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/../utils -DLIBEXECDIR=\"$(installlibexecdir)\"
 LDADD = $(top_builddir)/cache/libldcs_cache.la
 #AM_LDFLAGS = -all-static
 

--- a/src/server/auditserver/Makefile.in
+++ b/src/server/auditserver/Makefile.in
@@ -2,6 +2,7 @@
 # @configure_input@
 
 # Copyright (C) 1994-2013 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 
 # This Makefile.in is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -313,10 +314,11 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+installdir = @installdir@
 
 #noinst_LTLIBRARIES = libaudit_server_msocket.la libaudit_server_cobo.la libserverbase.la
 noinst_LTLIBRARIES = libaudit_server_cobo.la libserverbase.la
-AM_CPPFLAGS = -I$(top_srcdir)/comlib -I$(top_srcdir)/cache -I$(top_srcdir)/../cobo -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/../utils -DLIBEXECDIR=\"$(pkglibexecdir)\"
+AM_CPPFLAGS = -I$(top_srcdir)/comlib -I$(top_srcdir)/cache -I$(top_srcdir)/../cobo -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/../utils -DLIBEXECDIR=\"$(installdir)/libexec/spindle\"
 LDADD = $(top_builddir)/cache/libldcs_cache.la
 #AM_LDFLAGS = -all-static
 libserverbase_la_SOURCES = ldcs_audit_server_client_cb.c ldcs_audit_server_server_cb.c ldcs_audit_server_process.c ldcs_audit_server_filemngt.c ldcs_audit_server_handlers.c ldcs_elf_read.c ldcs_audit_server_requestors.c

--- a/src/server/configure
+++ b/src/server/configure
@@ -6,6 +6,7 @@
 #
 #
 # Copyright (C) 1992-1996, 1998-2012 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 #
 #
 # This configure script is free software; the Free Software Foundation
@@ -792,6 +793,7 @@ bindir
 program_transform_name
 prefix
 exec_prefix
+staging_prefix
 PACKAGE_URL
 PACKAGE_BUGREPORT
 PACKAGE_STRING
@@ -864,6 +866,7 @@ exec_prefix=NONE
 no_create=
 no_recursion=
 prefix=NONE
+staging_prefix=NONE
 program_prefix=NONE
 program_suffix=NONE
 program_transform_name=s,x,x,
@@ -880,6 +883,15 @@ x_libraries=NONE
 # by default will actually change.
 # Use braces instead of parens because sh, perl, etc. also accept them.
 # (The list follows the same order as the GNU Coding Standards.)
+
+if [ -z "$staging_prefix" ]; then
+        installlibdir='${prefix}/libdir}'
+        installlibexecdir='${prefix}/libexec}'
+else
+        installlibdir='${staging_prefix}/lib}'
+        installlibexecdir='${staging_prefix}/libexec}'
+fi
+
 bindir='${exec_prefix}/bin'
 sbindir='${exec_prefix}/sbin'
 libexecdir='${exec_prefix}/libexec'
@@ -1005,6 +1017,14 @@ do
   | --exec-pref=* | --exec-pre=* | --exec-pr=* | --exec-p=* | --exec-=* \
   | --exec=* | --exe=* | --ex=*)
     exec_prefix=$ac_optarg ;;
+
+  -staging-prefix | --staging_prefix | --staging-prefix | --staging-prefi \
+  | --staging-pref | --staging-pre | --staging-pr | --staging-p | --staging-)
+    staging_prefix=staging_prefix ;;
+  -staging-prefix=* | --staging_prefix=* | --staging-prefix=* | --staging-prefi=* \
+  | --staging-pref=* | --staging-pre=* | --staging-pr=* | --staging-p=* | --staging-=*)
+    staging_prefix=$ac_optarg ;;
+
 
   -gas | --gas | --ga | --g)
     # Obsolete; use --with-gas.
@@ -17919,6 +17939,7 @@ This config.status script is free software; the Free Software Foundation
 gives unlimited permission to copy, distribute and modify it."
 
 ac_pwd='$ac_pwd'
+installdir='$staging_prefix'
 srcdir='$srcdir'
 INSTALL='$INSTALL'
 MKDIR_P='$MKDIR_P'
@@ -18929,6 +18950,7 @@ s&@srcdir@&$ac_srcdir&;t t
 s&@abs_srcdir@&$ac_abs_srcdir&;t t
 s&@top_srcdir@&$ac_top_srcdir&;t t
 s&@abs_top_srcdir@&$ac_abs_top_srcdir&;t t
+s&@installdir@&$installdir&;t t
 s&@builddir@&$ac_builddir&;t t
 s&@abs_builddir@&$ac_abs_builddir&;t t
 s&@abs_top_builddir@&$ac_abs_top_builddir&;t t

--- a/src/server/logging/Makefile.in
+++ b/src/server/logging/Makefile.in
@@ -2,6 +2,7 @@
 # @configure_input@
 
 # Copyright (C) 1994-2013 Free Software Foundation, Inc.
+# Copyright (C) 2018 International Business Machines Corp.
 
 # This Makefile.in is free software; the Free Software Foundation
 # gives unlimited permission to copy and/or distribute it,
@@ -332,13 +333,14 @@ target_vendor = @target_vendor@
 top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
+installdir = @installdir@
 noinst_LTLIBRARIES = libspindlelogc.la
 spindled_logd_SOURCES = ../../logging/spindle_logd.cc
 spindled_logd_CPP = -I../../logging
 spindled_logd_LDADD = -lpthread
 libspindlelogc_la_SOURCES = ../../logging/spindle_logc.c
 libspindlelogc_la_CPP = -I../../logging
-libspindlelogc_la_CFLAGS = -DLIBEXEC=${pkglibexecdir} -DDAEMON_NAME=spindled_logd
+libspindlelogc_la_CFLAGS = -DLIBEXEC=${installdir}/libexec/spindle -DDAEMON_NAME=spindled_logd
 all: all-am
 
 .SUFFIXES:


### PR DESCRIPTION
spindle in one directory while planning to package into an RPM which will
be installed in a different directory.   So we add the configure option
--staging_prefix which maybe is itself poorly named.  The idea is that
it --staging_prefix can be used to set the final install location.   In this
case, many of the directories under this are assumed (especially libexec
and libexec/spindle).  I know there are other configure options to change
the details of where things are placed for --prefix, but our concern is with
things that are compiled into the code that refer to directories and these
are often hard coded with this change.  I would love to see a real solution
to this general problem of how to build spindle when it will later be installed
in a different location from where it is built.  I am not a configure/Makefile
expert obviously.

Example configure:

./configure \
  --enable-sec-none \
  --disable-testsuite \
  --prefix=$installdir \
  --staging_prefix=/opt/ibm/spindle