### PR TITLE
Fixed logging build/implementation to properly interpret --prefix=path for log daemon locations

### DIFF
--- a/src/client/logging/Makefile.am
+++ b/src/client/logging/Makefile.am
@@ -4,4 +4,4 @@ AM_CFLAGS = -fvisibility=hidden
 
 libspindlelogc_la_SOURCES = $(top_srcdir)/../logging/spindle_logc.c $(top_srcdir)/../utils/spindle_mkdir.c
 libspindlelogc_la_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -DSPINDLECLIENT
-libspindlelogc_la_CFLAGS = -DLIBEXEC=${pkglibexecdir} -DDAEMON_NAME=spindled_logd $(AM_CFLAGS)
+libspindlelogc_la_CFLAGS = -DLIBEXEC=\"${pkglibexecdir}\" -DDAEMON_NAME=\"spindled_logd\" $(AM_CFLAGS)

--- a/src/client/logging/Makefile.in
+++ b/src/client/logging/Makefile.in
@@ -294,7 +294,7 @@ noinst_LTLIBRARIES = libspindlelogc.la
 AM_CFLAGS = -fvisibility=hidden
 libspindlelogc_la_SOURCES = $(top_srcdir)/../logging/spindle_logc.c $(top_srcdir)/../utils/spindle_mkdir.c
 libspindlelogc_la_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -DSPINDLECLIENT
-libspindlelogc_la_CFLAGS = -DLIBEXEC=${pkglibexecdir} -DDAEMON_NAME=spindled_logd $(AM_CFLAGS)
+libspindlelogc_la_CFLAGS = -DLIBEXEC=\"${pkglibexecdir}\" -DDAEMON_NAME=\"spindled_logd\" $(AM_CFLAGS)
 all: all-am
 
 .SUFFIXES:

--- a/src/fe/logging/Makefile.am
+++ b/src/fe/logging/Makefile.am
@@ -7,4 +7,4 @@ spindlef_logd_LDADD = -lpthread
 
 libspindlelogc_la_SOURCES = $(top_srcdir)/../logging/spindle_logc.c $(top_srcdir)/../utils/spindle_mkdir.c
 libspindlelogc_la_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../utils -I$(top_srcdir)/../include
-libspindlelogc_la_CFLAGS = -DLIBEXEC=${pkglibexecdir} -DDAEMON_NAME=spindlef_logd
+libspindlelogc_la_CFLAGS = -DLIBEXEC=\"${pkglibexecdir}\" -DDAEMON_NAME=\"spindlef_logd\"

--- a/src/fe/logging/Makefile.in
+++ b/src/fe/logging/Makefile.in
@@ -337,7 +337,7 @@ spindlef_logd_CPPFLAGS = -I$(top_srcdir)/../logging
 spindlef_logd_LDADD = -lpthread
 libspindlelogc_la_SOURCES = $(top_srcdir)/../logging/spindle_logc.c $(top_srcdir)/../utils/spindle_mkdir.c
 libspindlelogc_la_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../utils -I$(top_srcdir)/../include
-libspindlelogc_la_CFLAGS = -DLIBEXEC=${pkglibexecdir} -DDAEMON_NAME=spindlef_logd
+libspindlelogc_la_CFLAGS = -DLIBEXEC=\"${pkglibexecdir}\" -DDAEMON_NAME=\"spindlef_logd\"
 all: all-am
 
 .SUFFIXES:

--- a/src/logging/spindle_logc.c
+++ b/src/logging/spindle_logc.c
@@ -39,9 +39,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #error Expected to have DAEMON_NAME defined
 #endif
 
-#define STR2(S) #S
-#define STR(S) STR2(S)
-#define LOG_DAEMON STR(LIBEXEC) "/" STR(DAEMON_NAME)
+static char spindle_log_daemon_name[] = LIBEXEC "/" DAEMON_NAME;
 
 static int debug_fd = -1;
 static int test_fd = -1;
@@ -76,7 +74,7 @@ void spawnLogDaemon(char *tempdir)
       if (result == 0) {
          char *params[7];
          int cur = 0;
-         params[cur++] = LOG_DAEMON;
+         params[cur++] = spindle_log_daemon_name;
          params[cur++] = tempdir;
          if (spindle_debug_prints) {
             params[cur++] = "-debug";
@@ -88,8 +86,8 @@ void spawnLogDaemon(char *tempdir)
          }
          params[cur++] = NULL;
          
-         execv(LOG_DAEMON, params);
-         fprintf(stderr, "Error executing %s: %s\n", LOG_DAEMON, strerror(errno));
+         execv(spindle_log_daemon_name, params);
+         fprintf(stderr, "Error executing %s: %s\n", spindle_log_daemon_name, strerror(errno));
          exit(0);
       }
       else {

--- a/src/server/logging/Makefile.am
+++ b/src/server/logging/Makefile.am
@@ -7,4 +7,4 @@ spindled_logd_LDADD = -lpthread
 
 libspindlelogc_la_SOURCES = ../../logging/spindle_logc.c
 libspindlelogc_la_CPP = -I../../logging
-libspindlelogc_la_CFLAGS = -DLIBEXEC=${pkglibexecdir} -DDAEMON_NAME=spindled_logd
+libspindlelogc_la_CFLAGS = -DLIBEXEC=\"${pkglibexecdir}\" -DDAEMON_NAME=\"spindled_logd\"

--- a/src/server/logging/Makefile.in
+++ b/src/server/logging/Makefile.in
@@ -338,7 +338,7 @@ spindled_logd_CPP = -I../../logging
 spindled_logd_LDADD = -lpthread
 libspindlelogc_la_SOURCES = ../../logging/spindle_logc.c
 libspindlelogc_la_CPP = -I../../logging
-libspindlelogc_la_CFLAGS = -DLIBEXEC=${pkglibexecdir} -DDAEMON_NAME=spindled_logd
+libspindlelogc_la_CFLAGS = -DLIBEXEC=\"${pkglibexecdir}\" -DDAEMON_NAME=\"spindled_logd\"
 all: all-am
 
 .SUFFIXES:


### PR DESCRIPTION
Fixed logging build and implementation files to treat the path part of the --prefix=path argument as a string by encapsulating the path in quotation marks.

This addresses issue #12 