### PR TITLE
Properly NULL-terminate string containing PID of daemon to kill

### DIFF
--- a/src/logging/spindle_logc.c
+++ b/src/logging/spindle_logc.c
@@ -128,7 +128,7 @@ int clearDaemon(char *tmpdir)
    if (fd != -1) {
       char pids[32], *cur = pids;
       while (read(fd, cur++, 1) == 1 && (cur - pids) < 32);
-      cur = '\0';
+      *cur = '\0';
       pid = atoi(pids);
       if (pid && kill(pid, 0) != -1) {
          /* The process exists, someone else likely re-created it */


### PR DESCRIPTION
The clang compiler produced a warning on line 131, which upon examination, would cause the pids string to not properly be null-terminated.