### PR TITLE
Added support for v2 ppc ABI

### DIFF
--- a/src/client/auditclient/Makefile.am
+++ b/src/client/auditclient/Makefile.am
@@ -21,6 +21,9 @@ endif
 if PPC64_BLD
 ARCH_SRCS = auditclient_ppc64.c
 endif
+if PPC64LE_BLD
+ARCH_SRCS = auditclient_ppc64.c
+endif
 
 AUDITLIB = $(top_builddir)/client/libspindle_audit.la
 

--- a/src/client/auditclient/Makefile.in
+++ b/src/client/auditclient/Makefile.in
@@ -136,9 +136,10 @@ am__libspindle_audit_biter_la_SOURCES_DIST = auditclient.c \
 	auditclient_ppc64.c auditclient_x86_64.c
 am__objects_1 = auditclient.lo auditclient_common.lo patch_linkmap.lo \
 	redirect.lo
-@PPC64_BLD_FALSE@@X86_64_BLD_TRUE@am__objects_2 =  \
-@PPC64_BLD_FALSE@@X86_64_BLD_TRUE@	auditclient_x86_64.lo
-@PPC64_BLD_TRUE@am__objects_2 = auditclient_ppc64.lo
+@PPC64LE_BLD_FALSE@@PPC64_BLD_FALSE@@X86_64_BLD_TRUE@am__objects_2 = auditclient_x86_64.lo
+@PPC64LE_BLD_FALSE@@PPC64_BLD_TRUE@am__objects_2 =  \
+@PPC64LE_BLD_FALSE@@PPC64_BLD_TRUE@	auditclient_ppc64.lo
+@PPC64LE_BLD_TRUE@am__objects_2 = auditclient_ppc64.lo
 am_libspindle_audit_biter_la_OBJECTS = $(am__objects_1) \
 	$(am__objects_2)
 libspindle_audit_biter_la_OBJECTS =  \
@@ -371,6 +372,7 @@ pkglib_LTLIBRARIES = $(am__append_1) $(am__append_2) $(am__append_3)
 AM_CFLAGS = -fvisibility=hidden
 AM_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/client -I$(top_srcdir)/client_comlib
 BASE_SRCS = auditclient.c auditclient_common.c patch_linkmap.c redirect.c
+@PPC64LE_BLD_TRUE@ARCH_SRCS = auditclient_ppc64.c
 @PPC64_BLD_TRUE@ARCH_SRCS = auditclient_ppc64.c
 @X86_64_BLD_TRUE@ARCH_SRCS = auditclient_x86_64.c
 AUDITLIB = $(top_builddir)/client/libspindle_audit.la

--- a/src/client/auditclient/auditclient_ppc64.c
+++ b/src/client/auditclient/auditclient_ppc64.c
@@ -228,8 +228,6 @@ static Elf64_Addr doPermanentBinding(uintptr_t *refcook, uintptr_t *defcook,
    got_entry[0] = func->fptr;
    got_entry[1] = func->toc;
 #else
-   debug_printf("Writing %p of %s to GOT location %p\n",
-       target, symname, got_entry);
    *got_entry = target;
 #endif
 


### PR DESCRIPTION
@mplegendre, here is the initial support for PPC V2 ABI that still uses la_ppc64*_gnu_pltenter.

I am still testing and this is not quite ready to be checked in but I wanted to give you a chance to review the changes if you wanted.

I am still investigating usage of 24-byte offsets instead of 8 and I am looking at potential usage of la_symbind instead of la_pltenter.