### PR TITLE
ldcs_hash: return newly added entry to prevent excess lookup

### DIFF
--- a/src/server/cache/ldcs_hash.c
+++ b/src/server/cache/ldcs_hash.c
@@ -36,7 +36,7 @@ ldcs_hash_key_t ldcs_hash_Val(const char *str) {
    return hash;
 }
 
-void ldcs_hash_addEntry(char *dirname, char *filename) {
+struct ldcs_hash_entry_t *ldcs_hash_addEntry(char *dirname, char *filename) {
    struct ldcs_hash_entry_t *newentry;
    ldcs_hash_key_t key = ldcs_hash_Val(filename);
    unsigned int index = (unsigned int) key % HASH_SIZE;
@@ -62,18 +62,17 @@ void ldcs_hash_addEntry(char *dirname, char *filename) {
 
    if (is_dir) {
       newentry->dir_next = NULL;
-      return;
+      return newentry;
    }
 
    struct ldcs_hash_entry_t *dent = ldcs_hash_Lookup(dirname);
    if (!dent) {
-      ldcs_hash_addEntry(dirname, dirname);
-      dent = ldcs_hash_Lookup(dirname);
+      dent = ldcs_hash_addEntry(dirname, dirname);
    }
    newentry->dir_next = dent->dir_next;
    dent->dir_next = newentry;
 
-   return;
+   return newentry;
 }
 
 struct ldcs_hash_entry_t *ldcs_hash_updateEntry(char *filename, char *dirname, char *localname, 

--- a/src/server/cache/ldcs_hash.h
+++ b/src/server/cache/ldcs_hash.h
@@ -44,7 +44,7 @@ struct ldcs_hash_entry_t
 
 int ldcs_hash_init();
 ldcs_hash_key_t ldcs_hash_Val(const char *str);
-void ldcs_hash_addEntry(char *dirname, char *filename);
+struct ldcs_hash_entry_t *ldcs_hash_addEntry(char *dirname, char *filename);
 
 struct ldcs_hash_entry_t *ldcs_hash_updateEntryOState(char *filename, char *dirname, int ostate);
 struct ldcs_hash_entry_t *ldcs_hash_updateEntry(char *filename, char *dirname, char *localname, 


### PR DESCRIPTION
This is a performance improvement to the ldcs cache. If the cache is very large, lookup times can be quite a burden. This removes an excess lookup. In my testing of the cache, this shaves about 2 seconds off of a 14 second init at very small scale. 