### PR TITLE
make testsuite script support Python 3

### DIFF
--- a/testsuite/hello.py
+++ b/testsuite/hello.py
@@ -1,3 +1,5 @@
 #!/bin/env python
 
-print "Hello, World"
+from __future__ import print_function
+
+print("Hello, World")


### PR DESCRIPTION
The one piece of Python in Spindle is not portable between Python 2 and Python 3.  This makes it work with Python 3.