### PR TITLE
Remove `lib` prefix check from spindle stat

### DIFF
--- a/src/client/client/should_intercept.c
+++ b/src/client/client/should_intercept.c
@@ -187,8 +187,7 @@ int stat_filter(const char *fname)
    last_slash = strrchr(fname, '/');
 
    if (is_dso(fname, last_slash, last_dot) ||
-       is_python(fname, last_dot) || 
-       is_lib_prefix(fname, last_slash))
+       is_python(fname, last_dot))
       return REDIRECT;
    else
       return ORIG_CALL;


### PR DESCRIPTION
 * With this in place `mkdir` and `stat` on directories and non-DSO files
   will fail. Encountered when working with a `libcoll_cache` directory.
