### PR TITLE
Exclude local path prefixes from being cached

### DIFF
--- a/src/client/client/client.c
+++ b/src/client/client/client.c
@@ -37,6 +37,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "client_api.h"
 #include "spindle_launch.h"
 #include "shmcache.h"
+#include "should_intercept.h"
 
 errno_location_t app_errno_location;
 
@@ -375,7 +376,13 @@ char *client_library_load(const char *name)
       test_log(name);
       return (char *) name;
    }
-   
+
+   /* Do not relocate if the file is to be excluded (e.g., on the local file system) */
+   if( is_excluded_path(name) ) {
+      test_log(name);
+      return (char *) name;
+   }
+
    sync_cwd();
 
    get_relocated_file(ldcsid, name, &newname, &errcode);

--- a/src/client/client/should_intercept.h
+++ b/src/client/client/should_intercept.h
@@ -32,5 +32,6 @@ int fopen_filter(const char *fname, const char *flags);
 int exec_filter(const char *fname);
 int stat_filter(const char *fname);
 int fd_filter(int fd);
+int is_excluded_path(const char *pathname);
 
 #endif


### PR DESCRIPTION
 * Feature enabled by default, but can be disabled by setting the
   envar `SPINDLE_DISABLE_EXCLUDE=1`
