### PR TITLE
Fix memory corruption crash

### DIFF
--- a/src/client/client/client.h
+++ b/src/client/client/client.h
@@ -96,6 +96,9 @@ extern int intercept_close;
 extern int intercept_fork;
 extern void int_spindle_test_log_msg(char *buffer);
 
+typedef void* (*malloc_sig_t)(size_t);
+malloc_sig_t get_libc_malloc();
+
 int lookup_libc_symbols();
 
 /* ERRNO_NAME currently refers to a glibc internal symbol. */


### PR DESCRIPTION
Fix bug where audit-side malloc would leak into app-side heap when rewriting library names for debuggers.  