### PR TITLE
Fixes logging suppression caused by early logging.

### DIFF
--- a/src/flux/flux-spindle.c
+++ b/src/flux/flux-spindle.c
@@ -345,9 +345,11 @@ static int sp_init (flux_plugin_t *p,
     /*  If SPINDLE_DEBUG is set in the environment of the job, propagate
      *  it into the shell so we get spindle debugging for this session.
      */
-    if ((debug = flux_shell_getenv (shell, "SPINDLE_DEBUG")))
+    if ((debug = flux_shell_getenv (shell, "SPINDLE_DEBUG"))){
         setenv ("SPINDLE_DEBUG", debug, 1);
-
+    }else{
+        setenv ("SPINDLE_DEBUG", "0", 1);
+    }
     /*  The spindle testsuite requires SPINDLE_TEST
      */
     if ((test = flux_shell_getenv (shell, "SPINDLE_TEST")))

--- a/src/logging/spindle_logc.h
+++ b/src/logging/spindle_logc.h
@@ -105,7 +105,7 @@ extern void spindle_dump_on_error();
       }                                                                 \
    } while (0)
 
-void init_spindle_debugging(char *name, int survive_exec);
+int init_spindle_debugging(char *name, int survive_exec);
 void fini_spindle_debugging();
 void reset_spindle_debugging();
 int is_debug_fd(int fd);


### PR DESCRIPTION
Logging initialization assumes a missing SPINDLE_DEBUG environment variable means SPINDLE_DEBUG=0.  Messages that are logged prior to that environment variable being set are lost and inadvertently suppress any further logging messages from that subsystem.

This patch sets SPINDLE_DEBUG=0 in the shell environment if that variable is missing from the flux environment.  It also modifies the logging initialization process so that any messages logged before SPINDLE_DEBUG is set are sent through, but any subsequent message will trigger re-initialization until SPINDLE_DEBUG exists.

Fixes #55 