### PR TITLE
Use --external-launcher for Slurm launch

### DIFF
--- a/configure.common.ac
+++ b/configure.common.ac
@@ -123,8 +123,8 @@ AS_CASE([$sysconfdir],
 BROKEN_SRUN=0
 bad_srun_major=20
 bad_srun_minor=11
-good_srun_major=0
-good_srun_minor=0
+good_srun_major=23
+good_srun_minor=11
 if test "x$ENABLE_SLURM" == "xtrue"; then
   AC_PATH_PROG(SRUN_PATH, "srun", "none")
   if test "x$SRUN_PATH" == "xnone"; then
@@ -135,10 +135,7 @@ if test "x$ENABLE_SLURM" == "xtrue"; then
   srun_major=`echo $srun_version | cut -d . -f 1`
   srun_minor=`echo $srun_version | cut -d . -f 2`
   srun_point=`echo $srun_version | cut -d . -f 3`
-  if ( [[ "$srun_major" == "$bad_srun_major" ]] && [[ $srun_minor -ge $bad_srun_minor ]] ) || [[ $srun_major -gt $bad_srun_major ]] ; then BROKEN_SRUN=1; fi
-  if test "x$good_srun_major" != "x0"; then
-    if ( [[ "$srun_major" == "$good_srun_major" ]] && [[ $srun_minor -ge $good_srun_minor ]] ) || [[ $srun_major -gt $good_srun_major ]] ; then BROKEN_SRUN=0; fi
-  fi
+  if ( [ "$srun_major" == "$good_srun_major" ] && [ $srun_minor -lt $good_srun_minor ] ) || [ $srun_major -lt $good_srun_major ]; then BROKEN_SRUN=1; fi
   
   if test "x$BROKEN_SRUN" == "x1"; then
     AC_MSG_RESULT([no])
@@ -165,7 +162,7 @@ fi
 if test "x$ENABLE_RSH_LAUNCH" == "x1"; then
   AC_DEFINE_UNQUOTED([RSHLAUNCH_ENABLED],[1],[Default mode for rsh launch])
 fi
-AC_DEFINE_UNQUOTED([BROKEN_SRUN],[1],[Whether we are using a broken srun])
+AC_DEFINE_UNQUOTED([BROKEN_SRUN],[$BROKEN_SRUN],[Whether we are using a broken srun])
             
 #Runmode detection (pipe/socket or cobo/msocket communications)
 if test "x$OS_BUILD" == "xlinux"; then

--- a/src/fe/startup/launch_slurm.cc
+++ b/src/fe/startup/launch_slurm.cc
@@ -159,10 +159,8 @@ bool SlurmLauncher::spawnDaemon()
       char count_buffer[64];
       snprintf(count_buffer, 64, "%d", nnodes);
       new_daemon_args[i++] = const_cast<char *>("srun");
-      new_daemon_args[i++] = const_cast<char *>("--ntasks-per-node=1");
+      new_daemon_args[i++] = const_cast<char *>("--external-launcher");
       new_daemon_args[i++] = const_cast<char *>("--wait=0");
-      new_daemon_args[i++] = const_cast<char *>("--gres=none");
-      new_daemon_args[i++] = const_cast<char *>("--mem=0");      
       new_daemon_args[i++] = const_cast<char *>("-n");
       new_daemon_args[i++] = count_buffer;
       new_daemon_args[i++] = const_cast<char *>("-N");


### PR DESCRIPTION
The Slurm `srun --external-launcher` option, added in 23.11, allows users to start a daemon that has access to all the resources without actually consuming any of them. It was intended for process managers like hydra, orted, or flux-as-a-step-manager to launch tasks, but I think we can use it here also.

The configury need more work, but I wanted to get some feedback before spending time on that. Nothing older than 23.11 is considered "supported" anymore. Does it make sense to completely remove the `BROKEN_SRUN` construct at this point?

```
ezy@borg005:~/mpi_hello> time spindle srun -n2240 -N40 ./mpihi >/dev/null

real    0m6.724s
user    0m0.021s
sys     0m0.054s
ezy@borg005:~/mpi_hello> time srun -n2240 -N40 ./mpihi >/dev/null

real    0m11.810s
user    0m0.015s
sys     0m0.044s
```