### PR TITLE
flux: reset SIGINT and SIGTERM signal handlers after fork()

### DIFF
--- a/src/flux/flux-spindle.c
+++ b/src/flux/flux-spindle.c
@@ -140,6 +140,14 @@ static int run_spindle_backend (struct spindle_ctx *ctx)
     if (ctx->backend_pid == 0) {
         /* N.B.: spindleRunBE() blocks, which is why we run it in a child
          */
+
+        /* Reset signal handlers in child, otherwise they are blocked.
+         * Note: this is a stopgap measure for now. Eventually the Flux
+         * job shell will automate this step with an atfork handler.
+         */
+        signal (SIGINT, SIG_DFL);
+        signal (SIGTERM, SIG_DFL);
+
         if (spindleRunBE (ctx->params.port,
                           ctx->params.num_ports,
                           ctx->id,
@@ -179,7 +187,7 @@ static void wait_for_shell_init (flux_future_t *f, void *arg)
     if (ctx->params.opts & OPT_OFF) {
        return;
     }
-    
+
     if (flux_job_event_watch_get (f, &event) < 0)
         shell_die_errno (1, "spindle failed waiting for shell.init event");
     if (!(o = json_loads (event, 0, NULL))


### PR DESCRIPTION
Problem: When the spindle flux plugin calls fork(2) to start the backend, it inherits the existing job shell signal disposition for SIGTERM and SIGINT. Since the main shell signal handler for these signals doesn't make sense in the spindle process, this leads to the backend process ignoring the signals at best, or a possible segfault at worst. In production this has been observed to leave jobs hanging in CLEANUP state under Flux when a job is canceled, which results in SIGTERM terminating the job tasks, the main shell process exits, but the spindle backend stays active.

Reset SIGTERM and SIGINT signal handlers to their default dispositions after fork(2) in the flux spindle plugin.

Note: Eventually the Flux job shell will install an atfork handler to take care of this in case any plugins call `fork()`. However, it won't hurt to have this in the Spindle plugin for Flux, and since a spindle update can be deployed more quickly than a Flux update in LC, this may be the most effective approach to resolve the issue quickly.

