### PR TITLE
Fixes #65 runTests not summarizing results correctly

### DIFF
--- a/testsuite/run_driver_template
+++ b/testsuite/run_driver_template
@@ -70,7 +70,11 @@ fi
 export SPINDLE_FLAGS="--level=high"
 
 ./run_driver_rm $TEST_EXEC $*
+RESULT=$?
 
 if [ x$STARTED_SPINDLE_SESSION == xtrue ]; then
 $SPINDLE --end-session $SESSION_ID
 fi
+
+exit $RESULT
+


### PR DESCRIPTION
Fixes #65 

Test case return values were not making it all the way back to the runTests script.  This PR adds an explicit exit call in the lower level script to propogate the return code back to the parent.

Results after testing:

Running: ./run_driver --dependency --push
FAILED.
flux-job: task(s) Unknown signal 127
SOME TESTS FAILED