### PR TITLE
Hide spindle from processes reading /proc/pid/maps

### DIFF
--- a/src/client/auditclient/auditclient_common.c
+++ b/src/client/auditclient/auditclient_common.c
@@ -144,7 +144,8 @@ unsigned int la_objclose (uintptr_t *cookie)
 
   map = get_linkmap_from_cookie(cookie);
   debug_printf3("la_objclose is for %s\n", map->l_name ? map->l_name : "[EMPTY]");
-  rm_wgot_library(map);
+  if (map->l_name && map->l_name[0])
+     rm_wgot_library(map);
 
   if(cookie == firstcookie) {
      debug_printf("Application process is starting to shut itself down\n");

--- a/src/client/client/intercept_open.c
+++ b/src/client/client/intercept_open.c
@@ -44,6 +44,7 @@ FILE* (*orig_fopen)(const char *pathname, const char *mode);
 FILE* (*orig_fopen64)(const char *pathname, const char *mode);
 int (*orig_close)(int fd);
 char* (*orig_dlerror)();
+static int handle_proc_pid_maps_open(const char *path, char **newpath);
 
 /* returns:
    0 if not existent
@@ -111,6 +112,14 @@ int open_worker(const char *path, int oflag, mode_t mode, int is_64)
    if (!path) {
       return call_orig_open(path, oflag, mode, is_64);
    }
+
+   result = handle_proc_pid_maps_open(path, &newpath);
+   if (result == 1) {
+      rc = call_orig_open(newpath, oflag, mode, is_64);
+      spindle_free(newpath);
+      return rc;
+   }
+   
    result = open_filter(path, oflag);
    if (ldcsid < 0 || result == ORIG_CALL) {
       /* Use the original open */
@@ -180,6 +189,13 @@ FILE *fopen_worker(const char *path, const char *mode, int is_64)
    if (!path) {
       return call_orig_fopen(path, mode, is_64);      
    }
+   result = handle_proc_pid_maps_open(path, &newpath);
+   if (result == 1) {
+      rc = call_orig_fopen(newpath, mode, is_64);
+      spindle_free(newpath);
+      return rc;
+   }
+
    result = fopen_filter(path, mode);
    if (ldcsid < 0 || result == ORIG_CALL) {
       /* Use the original open */
@@ -300,4 +316,72 @@ char *dlerror_wrapper()
       j++;
    }
    return message;
+}
+
+static int is_pid_maps(const char *s) {
+   int i = 0;
+   while (s[i] >= '0' && s[i] <= '9') i++;
+   if (strcmp(s + i, "/maps") != 0)
+      return -1;
+   return atoi(s);
+}
+
+static int is_self_maps(const char *s) {
+   if (strcmp(s, "self/maps") == 0)
+      return getpid();
+   return -1;
+}
+
+static int is_task_maps(const char *s) {
+   const char *t = strstr(s, "/task/");
+   if (!t)
+      return -1;
+   return is_pid_maps(t + 6);
+}
+
+static int handle_proc_pid_maps_open(const char *path, char **newpath)
+{
+   size_t len;
+   pid_t pid = -1, result = -1;
+   int query_result;
+   const char *centerpart;
+   char result_file[MAX_PATH_LEN+1];
+
+   
+   if (strncmp("/proc/", path, 6) != 0)
+      return 0;
+   len = strlen(path);
+   if (strcmp(path + len - 5, "/maps") != 0)
+      return 0;   
+   centerpart = path+6;
+   if ((result = is_pid_maps(centerpart)) != -1) {
+      // Matches pattern /proc/PID/maps"
+      pid = result;
+   }
+   else if ((result = is_self_maps(centerpart)) != -1) {
+      // Matches pattern /proc/self/maps"      
+      pid = result;
+   }
+   else if ((result = is_task_maps(centerpart)) != -1) {
+      // Matches pattern /proc/*/task/PID/maps"      
+      pid = result;
+   }
+   else {
+      debug_printf("Warning: Open /proc/*/maps file, of %s. But could not interpret pattern.\n", path);
+      return 0;
+   }
+
+   debug_printf2("Requesting /proc/maps redirection of pid %d for file %s\n", pid, path);
+   query_result = send_procmaps_query(ldcsid, pid, result_file);
+   if (query_result == -1) {
+      debug_printf2("Problem while communicating with server. Not redirecting /proc/maps open of %s\n", path);
+      return 0;
+   }
+   if (*result_file == '\0') {
+      debug_printf2("Server instructed us to self open /proc/maps file %s\n", path);
+      return 0;
+   }
+   *newpath = spindle_strdup(result_file);
+   debug_printf2("Redirected /proc/maps of pid %d for file %s to file %s\n", pid, path, *newpath);
+   return 1;
 }

--- a/src/client/client/intercept_stat.c
+++ b/src/client/client/intercept_stat.c
@@ -143,8 +143,9 @@ int rtcache_lstat(const char *path, struct stat *buf)
 int rtcache_xstat(int vers, const char *path, struct stat *buf)
 {
    int result = handle_stat(path, buf, IS_XSTAT);
-   if (result != ORIG_STAT)
+   if (result != ORIG_STAT) {
       return result;
+   }
    return orig_xstat(vers, path, buf);
 }
 

--- a/src/client/client/should_intercept.c
+++ b/src/client/client/should_intercept.c
@@ -240,8 +240,14 @@ int stat_filter(const char *fname)
       return REDIRECT;
 
    if (is_in_spindle_cache(fname)) {
-      debug_printf3("Redirection stat of %s, which is in spindle cache\n", fname);
-      return REDIRECT;
+      if (!strstr(fname, "spindle_proc_maps_")) {
+         debug_printf3("Redirection stat of %s, which is in spindle cache\n", fname);
+         return REDIRECT;
+      }
+      else {
+         debug_printf3("Allowing stat of rewritten /proc/pid/maps file %s to go to local file\n", fname);
+         return ORIG_CALL;
+      }
    }
    if (is_local_file(fname)) {
       debug_printf3("Not intercepting stat of %s, because local file\n", fname);      

--- a/src/client/client_comlib/client_api.c
+++ b/src/client/client_comlib/client_api.c
@@ -382,6 +382,37 @@ int send_rankinfo_query(int fd, int *mylrank, int *mylsize, int *mymdrank, int *
    return 0;
 }
 
+int send_procmaps_query(int fd, int pid, char *result)
+{
+   ldcs_message_t message;
+   char buffer[MAX_PATH_LEN+1];
+
+   debug_printf3("Sending procmaps query\n");
+
+   message.header.type = LDCS_MSG_PROCMAPS_REQ;
+   message.header.len = sizeof(int);
+   message.data=buffer;
+   memcpy(message.data, &pid, sizeof(int));
+
+   COMM_LOCK;
+
+   client_send_msg(fd, &message);
+
+   client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+
+   COMM_UNLOCK;
+
+   if (message.header.type != LDCS_MSG_PROCMAPS_RESP) {
+      err_printf("Received incorrect response to procmaps query %d\n", message.header.type);
+      assert(0);
+   }
+
+   memcpy(result, buffer, MAX_PATH_LEN);
+   debug_printf3("Received procmaps translation of %d to %s\n", pid, result);
+   
+   return 0;   
+}
+
 int send_end(int fd) {
    ldcs_message_t message;
    

--- a/src/client/client_comlib/client_api.h
+++ b/src/client/client_comlib/client_api.h
@@ -39,6 +39,7 @@ int send_stat_request(int fd, char *path, int islstat, char *result);
 int send_ldso_info_request(int fd, const char *ldso_path, char *result_path);
 int send_orig_path_request(int fd, const char *path, char *newpath);
 int send_local_prefix_request(int fd, char **result);
+int send_procmaps_query(int fd, int pid, char *result);
 
 int get_python_prefix(int fd, char **prefix);
 

--- a/src/include/ldcs_api.h
+++ b/src/include/ldcs_api.h
@@ -78,6 +78,8 @@ typedef enum {
    LDCS_MSG_EXIT,
    LDCS_MSG_BUNDLE,
    LDCS_MSG_ALIAS,
+   LDCS_MSG_PROCMAPS_REQ,
+   LDCS_MSG_PROCMAPS_RESP,
    LDCS_MSG_UNKNOWN
 } ldcs_message_ids_t;
 

--- a/src/server/auditserver/Makefile.am
+++ b/src/server/auditserver/Makefile.am
@@ -5,7 +5,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/comlib -I$(top_srcdir)/cache -I$(top_srcdir)/../co
 LDADD = $(top_builddir)/cache/libldcs_cache.la -lrt
 #AM_LDFLAGS = -all-static
 
-libserverbase_la_SOURCES = ldcs_audit_server_client_cb.c ldcs_audit_server_server_cb.c ldcs_audit_server_process.c ldcs_audit_server_filemngt.c ldcs_audit_server_handlers.c ldcs_elf_read.c ldcs_audit_server_requestors.c ldcs_audit_server_numa.c msgbundle.c parse_mounts.cc cleanup_proc.cc
+libserverbase_la_SOURCES = ldcs_audit_server_client_cb.c ldcs_audit_server_server_cb.c ldcs_audit_server_process.c ldcs_audit_server_filemngt.c ldcs_audit_server_handlers.c ldcs_elf_read.c ldcs_audit_server_requestors.c ldcs_audit_server_numa.c msgbundle.c parse_mounts.cc cleanup_proc.cc translate_maps.c
 libserverbase_la_LIBADD = -lpthread
 
 #libaudit_server_msocket_la_SOURCES = ldcs_audit_server_md_msocket.c ldcs_audit_server_md_msocket_util.c ldcs_audit_server_md_msocket_topo.c 

--- a/src/server/auditserver/Makefile.in
+++ b/src/server/auditserver/Makefile.in
@@ -124,7 +124,7 @@ am_libserverbase_la_OBJECTS = ldcs_audit_server_client_cb.lo \
 	ldcs_audit_server_filemngt.lo ldcs_audit_server_handlers.lo \
 	ldcs_elf_read.lo ldcs_audit_server_requestors.lo \
 	ldcs_audit_server_numa.lo msgbundle.lo parse_mounts.lo \
-	cleanup_proc.lo
+	cleanup_proc.lo translate_maps.lo
 libserverbase_la_OBJECTS = $(am_libserverbase_la_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -151,7 +151,7 @@ am__depfiles_remade = ./$(DEPDIR)/cleanup_proc.Plo \
 	./$(DEPDIR)/ldcs_audit_server_requestors.Plo \
 	./$(DEPDIR)/ldcs_audit_server_server_cb.Plo \
 	./$(DEPDIR)/ldcs_elf_read.Plo ./$(DEPDIR)/msgbundle.Plo \
-	./$(DEPDIR)/parse_mounts.Plo
+	./$(DEPDIR)/parse_mounts.Plo ./$(DEPDIR)/translate_maps.Plo
 am__mv = mv -f
 COMPILE = $(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) \
 	$(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS)
@@ -376,7 +376,7 @@ noinst_LTLIBRARIES = libaudit_server_cobo.la libserverbase.la
 AM_CPPFLAGS = -I$(top_srcdir)/comlib -I$(top_srcdir)/cache -I$(top_srcdir)/../cobo -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/../utils -DLIBEXECDIR=\"$(pkglibexecdir)\"
 LDADD = $(top_builddir)/cache/libldcs_cache.la -lrt
 #AM_LDFLAGS = -all-static
-libserverbase_la_SOURCES = ldcs_audit_server_client_cb.c ldcs_audit_server_server_cb.c ldcs_audit_server_process.c ldcs_audit_server_filemngt.c ldcs_audit_server_handlers.c ldcs_elf_read.c ldcs_audit_server_requestors.c ldcs_audit_server_numa.c msgbundle.c parse_mounts.cc cleanup_proc.cc
+libserverbase_la_SOURCES = ldcs_audit_server_client_cb.c ldcs_audit_server_server_cb.c ldcs_audit_server_process.c ldcs_audit_server_filemngt.c ldcs_audit_server_handlers.c ldcs_elf_read.c ldcs_audit_server_requestors.c ldcs_audit_server_numa.c msgbundle.c parse_mounts.cc cleanup_proc.cc translate_maps.c
 libserverbase_la_LIBADD = -lpthread
 
 #libaudit_server_msocket_la_SOURCES = ldcs_audit_server_md_msocket.c ldcs_audit_server_md_msocket_util.c ldcs_audit_server_md_msocket_topo.c 
@@ -454,6 +454,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ldcs_elf_read.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/msgbundle.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/parse_mounts.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/translate_maps.Plo@am__quote@ # am--include-marker
 
 $(am__depfiles_remade):
 	@$(MKDIR_P) $(@D)
@@ -652,6 +653,7 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/ldcs_elf_read.Plo
 	-rm -f ./$(DEPDIR)/msgbundle.Plo
 	-rm -f ./$(DEPDIR)/parse_mounts.Plo
+	-rm -f ./$(DEPDIR)/translate_maps.Plo
 	-rm -f Makefile
 distclean-am: clean-am distclean-compile distclean-generic \
 	distclean-tags
@@ -709,6 +711,7 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/ldcs_elf_read.Plo
 	-rm -f ./$(DEPDIR)/msgbundle.Plo
 	-rm -f ./$(DEPDIR)/parse_mounts.Plo
+	-rm -f ./$(DEPDIR)/translate_maps.Plo
 	-rm -f Makefile
 maintainer-clean-am: distclean-am maintainer-clean-generic
 

--- a/src/server/auditserver/ldcs_audit_server_filemngt.c
+++ b/src/server/auditserver/ldcs_audit_server_filemngt.c
@@ -729,4 +729,20 @@ int filemngt_is_elf_file(const char *buffer, size_t buffer_size)
            (buffer[2] == 'L') &&
            (buffer[3] == 'F'));
 }
+
+
+int filemngt_convert_proc_maps(int pid, char *new_maps_filename, int new_maps_filename_size)
+{
+   int result;
+   debug_printf2("Asked to convert /proc/%d/maps to remove spindle paths\n", pid);
    
+   result = translate_proc_pid_maps(_ldcs_audit_server_tmpdir, pid, new_maps_filename, new_maps_filename_size);
+   if (result == -1) {
+      new_maps_filename[0] = '\0';
+      return -1;
+   }
+   
+   debug_printf2("Converted /proc/%d/maps to %s\n", pid, new_maps_filename);
+
+   return 0;
+}

--- a/src/server/auditserver/ldcs_audit_server_filemngt.h
+++ b/src/server/auditserver/ldcs_audit_server_filemngt.h
@@ -60,5 +60,6 @@ int filemngt_read_ldsometadata(char *localname, ldso_info_t *ldsoinfo);
 int filemngt_is_elf_file(const char *buffer, size_t buffer_size);
 int filemngt_get_ldso_metadata(char *pathname, ldso_info_t *ldsoinfo);
 int filemngt_realpath(char *pathname, char *realfile);
-
+int filemngt_convert_proc_maps(int pid, char *new_maps_filename, int new_maps_filename_size);
+extern int translate_proc_pid_maps(char *output_dir, int pid, char *output_file, int output_file_size);
 #endif

--- a/src/server/auditserver/ldcs_audit_server_handlers.c
+++ b/src/server/auditserver/ldcs_audit_server_handlers.c
@@ -161,6 +161,7 @@ static int handle_metadata_recv(ldcs_process_data_t *procdata, ldcs_message_t *m
 static int handle_client_metadata(ldcs_process_data_t *procdata, int nc);
 static int handle_client_metadata_result(ldcs_process_data_t *procdata, int nc, metadata_t mdtype);
 static int handle_client_metadata_self(ldcs_process_data_t *procdata, int nc);
+static int handle_client_procmaps_msg(ldcs_process_data_t *procdata, int nc, ldcs_message_t *msg);
 static int handle_metadata_request(ldcs_process_data_t *procdata, char *pathname, metadata_t mdtype, node_peer_t from);
 static int handle_metadata_request_recv(ldcs_process_data_t *procdata, ldcs_message_t *msg, metadata_t mdtype, node_peer_t peer);
 static int handle_load_and_broadcast_metadata(ldcs_process_data_t *procdata, char *pathname, metadata_t mdtype);
@@ -175,7 +176,6 @@ static int handle_msgbundle(ldcs_process_data_t *procdata, node_peer_t peer, ldc
 static int handle_setup_alias(ldcs_process_data_t *procdata, char *pathname, char *alias_to);
 static int handle_client_localprefix_req(ldcs_process_data_t *procdata, int nc);
 static int handle_close_client_query(ldcs_process_data_t *procdata, int nc);
-
 /**
  * Query from client to server.  Returns info about client's rank in server data structures. 
  **/
@@ -1857,6 +1857,8 @@ int handle_client_message(ldcs_process_data_t *procdata, int nc, ldcs_message_t 
          return handle_client_fileexist_msg(procdata, nc, msg);
       case LDCS_MSG_ORIGPATH_QUERY:
          return handle_client_origpath_msg(procdata, nc, msg);
+      case LDCS_MSG_PROCMAPS_REQ:
+         return handle_client_procmaps_msg(procdata, nc, msg);
       case LDCS_MSG_END:
          return handle_client_end(procdata, nc);
       default:
@@ -2642,7 +2644,7 @@ static int handle_client_metadata_result(ldcs_process_data_t *procdata, int nc, 
    if (result == -1) {
       debug_printf3("File %s does not yet have stat results\n", client->query_globalpath);
       return 0;
-   }
+   }   
    
    msg.header.type = (mdtype == metadata_stat || mdtype == metadata_lstat) ? LDCS_MSG_STAT_ANSWER : LDCS_MSG_LOADER_DATA_RESP;
    msg.header.len = localpath ? strlen(localpath)+1 : 0;
@@ -2803,6 +2805,46 @@ static int handle_load_and_broadcast_metadata(ldcs_process_data_t *procdata, cha
    }
 
    return 0;
+}
+
+/**
+ * A client is open a /proc/ * /maps file. Create a replacement file that doesn't contain spindle paths
+ * and pass it back to the client.
+ **/
+static int handle_client_procmaps_msg(ldcs_process_data_t *procdata, int nc, ldcs_message_t *msg)
+{
+   ldcs_client_t *client;
+   int pid, result;
+   char newfile[MAX_PATH_LEN+1];
+   ldcs_message_t outmsg;
+   
+   assert(nc != -1);
+   client = procdata->client_table + nc;
+
+   assert(msg->header.len == sizeof(int));
+   memcpy(&pid, msg->data, sizeof(int));
+
+   result = filemngt_convert_proc_maps(pid, newfile, sizeof(newfile));
+   if (result == -1) {
+      debug_printf2("Telling client to self open maps file for pid %d\n", pid);
+      newfile[0] = '\0';
+   }
+   else {
+      debug_printf2("Telling client to open /proc/maps at pid %d with file %s\n", pid, newfile);
+      
+   }
+
+   outmsg.header.type = LDCS_MSG_PROCMAPS_RESP;
+   outmsg.header.len = strlen(newfile) + 1;
+   outmsg.data = newfile;
+
+   result = ldcs_send_msg(client->connid, &outmsg);
+   procdata->server_stat.clientmsg.cnt++;
+   procdata->server_stat.clientmsg.time+=(ldcs_get_time() - client->query_arrival_time);
+   handle_close_client_query(procdata, nc);
+   
+   return 0;
+   
 }
 
 /**

--- a/src/server/auditserver/translate_maps.c
+++ b/src/server/auditserver/translate_maps.c
@@ -1,0 +1,229 @@
+/*
+This file is part of Spindle.  For copyright information see the COPYRIGHT 
+file in the top level directory, or at 
+https://github.com/hpc/Spindle/blob/master/COPYRIGHT
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License (as published by the Free Software
+Foundation) version 2.1 dated February 1999.  This program is distributed in the
+hope that it will be useful, but WITHOUT ANY WARRANTY; without even the IMPLIED
+WARRANTY OF MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms 
+and conditions of the GNU Lesser General Public License for more details.  You should 
+have received a copy of the GNU Lesser General Public License along with this 
+program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "ldcs_audit_server_filemngt.h"
+#include "global_name.h"
+#include "spindle_debug.h"
+
+static int open_proc_maps(int pid)
+{
+   int fd;
+   char filename[MAX_NAME_LEN+1];
+   int error;
+   snprintf(filename, MAX_NAME_LEN, "/proc/%d/maps", pid);
+   filename[MAX_NAME_LEN] = '\0';
+   fd = open(filename, O_RDONLY);
+   if (fd == -1) {
+      error = errno;
+      err_printf("Error opening /proc/%d/maps for translation: %s\n", pid, strerror(error));
+      return -1;
+   }
+   return fd;
+}
+
+static int open_replacement_proc_maps(char *spindle_dir, int pid, char *output_file, int output_file_size)
+{
+   int fd;
+   int error;
+   static int uniqnum = 0;
+
+   snprintf(output_file, output_file_size, "%s/spindle_proc_maps_%d_%d", spindle_dir, pid, uniqnum++);
+   output_file[MAX_NAME_LEN] = '\0';   
+   fd = open(output_file, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+   if (fd == -1) {
+      error = errno;
+      err_printf("Unable to open replacement proc maps for process %d in %s: %s\n",
+                 pid, spindle_dir, strerror(error));
+      return -1;
+   }
+   output_file[output_file_size-1] = '\0';
+   return fd;
+}
+
+#define BUFFER_SIZE 4096
+struct buffer_info_t {
+   char *buffer;
+   int buffer_pos;
+   int buffer_size;
+   int max_buffer_size;
+};
+
+static int read_into_buffer(int fd, struct buffer_info_t *buf) {
+   int result, error;
+
+   do {
+      result = read(fd, buf->buffer, buf->max_buffer_size);
+   } while (result == -1 && errno == EINTR);
+   if (result == -1) {
+      error = errno;
+      err_printf("Error reading from from /proc/maps for interception: %s\n", strerror(error));
+      return -1;
+   }
+   if (result == 0)
+      return 0;
+   buf->buffer_size = result;
+   buf->buffer_pos = 0;
+   return result;
+}
+   
+static int read_one_line(int fd, char *line, int *linelen, int maxlinelen, struct buffer_info_t *buf) {
+   int pos = 0;
+   char c;
+   int result;
+
+   *linelen = 0;
+   
+   for (;;) {
+      if (buf->buffer_size == 0 || buf->buffer_pos == buf->buffer_size) {
+         result = read_into_buffer(fd, buf);
+         if (result == -1)
+            return -1;
+         if (result == 0)
+            return 0;
+      }
+      c = buf->buffer[buf->buffer_pos];
+      buf->buffer_pos++;
+      if (c == '\n') {
+         if (pos < maxlinelen)
+            line[pos] = '\0';
+         break;
+      }
+      if (pos < maxlinelen) {
+         line[pos] = c;
+         *linelen = pos+1;
+      }
+      pos++;
+   }
+   line[maxlinelen-1] = '\0';
+   return 0;
+}
+
+static int write_line(int fd, char *line, int linelen)
+{
+   int pos = 0, result, error;
+   do {
+      result = write(fd, line + pos, linelen - pos);
+      if (result == -1 && errno == EINTR)
+         continue;
+      if (result == -1) {
+         error = errno;
+         err_printf("Error writing to new proc maps: %s\n", strerror(error));
+         return -1;
+      }
+      pos += result;
+   } while (pos < linelen);
+   return 0;
+}
+
+static void add_newline(char *line, int *linelen, int maxlen)
+{
+   if (*linelen < maxlen-2) {
+      line[*linelen] = '\n';
+      *linelen = *linelen + 1;
+      line[*linelen] = '\0';
+   }
+   else {
+      line[maxlen-2] = '\n';
+      line[maxlen-1] = '\0';
+      *linelen = maxlen - 1;
+   }
+}
+
+static int translate_line(char *spindle_dir, char *line, int *linelen, int maxlen)
+{
+   char *p;
+   char *newname;
+
+   char *lastpart = strrchr(spindle_dir, '/');
+   if (!lastpart)
+      lastpart = spindle_dir;
+   if (*(lastpart+1) == '\0') {
+      lastpart--;
+      while (lastpart != line && *lastpart != '/') lastpart--;
+   }
+
+   p = strstr(line, lastpart);
+   if (!p) {
+      return 0;
+   }
+
+   while (p != line && *(p-1) != ' ')
+      p--;
+
+   newname = lookup_global_name(p);
+   if (!newname) {
+      return 0;
+   }
+   debug_printf3("Translating path '%s' to '%s' in maps file\n", p, newname);
+   strncpy(p, newname, maxlen - (p - line) - 1);
+   *linelen = strlen(line);
+
+   return 0;
+}
+
+#define MAX_PROC_MAPS_LINESZ 8192
+int translate_proc_pid_maps(char *spindle_dir, int pid, char *output_file, int output_file_size)
+{
+   int fd, newfd;
+   int result;
+   struct buffer_info_t buf;
+   char working_buf[BUFFER_SIZE];
+   char line[MAX_PROC_MAPS_LINESZ];
+   int linelen;
+
+
+   fd = open_proc_maps(pid);
+   if (fd == -1) {
+      return -1;
+   }
+
+   newfd = open_replacement_proc_maps(spindle_dir, pid, output_file, output_file_size);
+   if (fd == -1) {
+      close(fd);
+      return -1;
+   }
+
+   buf.buffer = working_buf;
+   buf.buffer_pos = 0;
+   buf.buffer_size = 0;
+   buf.max_buffer_size = sizeof(working_buf);
+
+   for (;;) {
+      result = read_one_line(fd, line, &linelen, sizeof(line), &buf);
+      if (result == -1)
+         break;
+      
+      if (linelen <= 1)
+         break;
+      translate_line(spindle_dir, line, &linelen, sizeof(line));
+      add_newline(line, &linelen, sizeof(line));
+      result = write_line(newfd, line, linelen);
+      if (result == -1)
+         break;
+   }
+   close(fd);
+   close(newfd);
+   return result;
+}
+

--- a/src/server/comlib/ldcs_api_util.c
+++ b/src/server/comlib/ldcs_api_util.c
@@ -85,6 +85,8 @@ char* _message_type_to_str (ldcs_message_ids_t type) {
       STR_CASE(LDCS_MSG_EXIT_CANCEL);
       STR_CASE(LDCS_MSG_BUNDLE);
       STR_CASE(LDCS_MSG_ALIAS);
+      STR_CASE(LDCS_MSG_PROCMAPS_REQ);
+      STR_CASE(LDCS_MSG_PROCMAPS_RESP);      
       STR_CASE(LDCS_MSG_UNKNOWN);
    }
    return "unknown";

--- a/testsuite/test_driver.c
+++ b/testsuite/test_driver.c
@@ -13,6 +13,8 @@ have received a copy of the GNU Lesser General Public License along with this
 program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
+#define _GNU_SOURCE
+
 #include "config.h"
 #if defined(HAVE_MPI)
 #include <mpi.h>
@@ -33,6 +35,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <elf.h>
 #include <link.h>
 #include <sys/mman.h>
+#include <sys/types.h>
+#include <dirent.h>
 
 #include "spindle.h"
 #include "ccwarns.h"
@@ -60,6 +64,7 @@ int had_error;
    do {                                                                 \
       snprintf(test_buffer, 4096, "Error - [%s:%u] - " format, __FILE__, __LINE__, ## __VA_ARGS__); \
       spindle_test_log_msg(test_buffer);                                \
+      fprintf(stderr, "%s\n", test_buffer);                             \
       had_error = 1;                                                    \
    } while (0); 
 
@@ -305,8 +310,11 @@ static void check_symt(char *path)
   done:
    if (mmap_result)
       munmap(mmap_result, buf.st_size);
-   if (fd != -1)
-      close(fd);
+   /**
+    * Don't close fds from open. We'll test them later to see if readlink sees spindle paths in them
+    *    if (fd != -1)
+    *       close(fd);
+    */
 }
 
 static void open_library(int i)
@@ -894,6 +902,183 @@ void checkTlsSum()
 
 }
 
+static char* getCacheLocation(char *env_var)
+{
+   char *result, *last_slash;
+
+   result = getenv(env_var);
+   if (!result || result[0] == '\0')
+      return NULL;
+
+   last_slash = strrchr(result, '/');
+   if (!last_slash)
+      return strdup(result);
+   if (last_slash[1] != '\0')
+      return strdup(last_slash+1);
+   while (last_slash != result && last_slash[-1] != '/') last_slash--;
+   return strdup(last_slash);
+}
+
+static int checkLinkForLeak(const char *path, const char *spindle_loc)
+{
+   char link_target[4096];
+   int result, error;
+   memset(link_target, 0, sizeof(link_target));
+
+   result = readlink(path, link_target, sizeof(link_target));
+   if (result == -1) {
+      error = errno;
+      err_printf("Failed to read link %s: %s\n", path, strerror(error));
+      return -1;
+   }
+
+   if (strstr(link_target, spindle_loc)) {
+      err_printf("Link at '%s' has path '%s', which leaks spindle path with '%s'\n", path, link_target, spindle_loc);
+      return -1;
+   }
+
+   return 0;
+}
+
+static int checkPathForLeak(const char *what, const char *path, const char *spindle_loc)
+{
+   if (strstr(path, spindle_loc)) {
+      err_printf("%s: Path '%s' leaks spindle path with '%s'\n", what, path, spindle_loc);
+      return -1;
+   }
+   return 0;
+}
+
+static int leak_check_cb(struct dl_phdr_info *p, size_t psize, void *opaque)
+{
+   char *spindle_loc = (char *) opaque;
+   if (!p->dlpi_name || p->dlpi_name[0] == '\0')
+      return 0;
+   checkPathForLeak("dl_iterate_phdr", p->dlpi_name, spindle_loc);
+   return 0;
+}
+
+static int check_proc_maps(char *path, char *spindle_loc)
+{
+   int fd, error, result;
+   struct stat statbuf;
+   char *maps = NULL;
+   size_t filesize, pos = 0;
+
+   fd = open(path, O_RDONLY);
+   if (fd == -1) {
+      error = errno;
+      err_printf("Failed to open %s: %s\n", path, strerror(error));
+      return -1;
+   }
+
+   result = fstat(fd, &statbuf);
+   if (result == -1) {
+      error = errno;
+      err_printf("Failed to stat %s: %s\n", path, strerror(error));
+      close(fd);
+      return -1;
+   }
+   filesize = statbuf.st_size;
+
+   maps = (char *) malloc(filesize + 1);
+   do {
+      result = read(fd, maps+pos, filesize-pos);
+      if (result == -1 && errno == EINTR)
+         continue;
+      if (result == -1) {
+         error = errno;
+         err_printf("Failed to read from %s: %s\n", path, strerror(error));
+         close(fd);
+         return -1;
+      }
+      pos += result;
+   } while (pos < filesize);
+   maps[filesize] = '\0';
+   close(fd);
+
+   if (strstr(maps, spindle_loc)) {
+      err_printf("Found leaked spindle path '%s' in maps '%s'\n", spindle_loc, path);
+      return -1;
+   }
+
+   free(maps);   
+   return 0;
+}
+
+void check_for_path_leaks()
+{
+   char *spindle_loc = NULL;
+   DIR *proc_fds = NULL;
+   struct dirent *d;
+   char path[4096];
+   struct link_map *lm;
+   char *dlerr_msg = NULL;
+
+   spindle_loc = getCacheLocation("LDCS_LOCATION");
+   if (!spindle_loc)
+      spindle_loc = getCacheLocation("LDCS_ORIG_LOCATION");
+   if (!spindle_loc) {
+      err_printf("Failed to calculate cache location");
+      goto done;
+   }
+
+   /**
+    * Check symlinks in /proc/self/exe and /proc/self/fd/[*]  for leaks of spindle paths.
+    **/
+   proc_fds = opendir("/proc/self/fd");
+   if (!proc_fds) {
+      err_printf("Could not open directory /proc/self/fd");
+      goto done;
+   }
+   for (d = readdir(proc_fds); d != NULL; d = readdir(proc_fds)) {
+      if (d->d_name[0] == '.')
+         continue;
+      strncpy(path, "/proc/self/fd/", sizeof(path));
+      strncat(path, d->d_name, sizeof(path)-1);
+      checkLinkForLeak(path, spindle_loc);
+   }
+   checkLinkForLeak("/proc/self/exe", spindle_loc);
+
+   /**
+    * Check link_maps for leaked spindle paths
+    **/
+   for (lm = _r_debug.r_map; lm != NULL; lm = lm->l_next) {
+      if (!lm->l_name || lm->l_name[0] == '\0')
+         continue;
+      checkPathForLeak("link_map", lm->l_name, spindle_loc);
+   }
+
+   /**
+    * Check libraries in dl_iterate_phdr for leaked paths
+    **/
+   dl_iterate_phdr(leak_check_cb, spindle_loc);
+
+   /**
+    * Check /proc/pid/maps under various aliases for leaked names
+    **/
+   check_proc_maps("/proc/self/maps", spindle_loc);
+   snprintf(path, sizeof(path), "/proc/self/task/%d/maps", getpid());
+   check_proc_maps(path, spindle_loc);
+   snprintf(path, sizeof(path), "/proc/%d/maps", getpid());
+   check_proc_maps(path, spindle_loc);
+
+   /**
+    * Check that dlerror doesn't leak the /__not_exists/ prefix
+    **/
+   dlopen("libnosuchlib.so", RTLD_NOW);
+   dlerr_msg = dlerror();
+   if (dlerr_msg && strstr(dlerr_msg, "/__not_exists/")) {
+      err_printf("Found not exists message in dlerror message: %s\n", dlerr_msg);
+   }
+   
+  done:
+   if (spindle_loc)
+      free(spindle_loc);
+   if (proc_fds)
+      closedir(proc_fds);
+}
+
 void close_libs()
 {
    int i, result;
@@ -933,6 +1118,10 @@ int run_test()
       return -1;
 
    call_funcs();
+   if (had_error)
+      return -1;
+
+   check_for_path_leaks();
    if (had_error)
       return -1;
 


### PR DESCRIPTION
A traditional way to check if spindle was running on an application was to look at its /proc/pid/maps and see if it contains spindle paths. But the amd gpu runtime started reading /proc/pid/maps itself to look at library paths and then load config files relative to the paths it found. This broke with spindle, as the runtime was redirected to try config loading from spindle's local paths.

This PR fixes this by intercepting opens of /proc/pid/maps with spindle and redirecting the open to a modified version of /proc/pid/maps file that contains original paths. 

After this change running 'cat /proc/self/maps' under spindle is no longer an easy smoke test to see if spindle is relocating libraries.

This PR also adds tests that check reading /proc/pid/maps, and other known methods by which spindle local paths were leaking into the application.