### PR TITLE
Fix issues with incomplete cleanup in flux after ctrl c, and fixes for libraries loaded from /tmp

### DIFF
--- a/src/fe/startup/config_mgr.cc
+++ b/src/fe/startup/config_mgr.cc
@@ -226,7 +226,7 @@ const list<SpindleOption> Options = {
      "Colon-seperated list of directories that contain the python install locations." },
    { confCachePrefix, "cache-prefix", shortCachePrefix, groupMisc, cvList, {}, "",
      "Alias for python-prefix" },
-   { confLocalPrefix, "local-prefix", shortLocalPrefix, groupMisc, cvList, {}, SPINDLE_LOC_STR ":$TMPDIR/:/proc/:/dev/",
+   { confLocalPrefix, "local-prefix", shortLocalPrefix, groupMisc, cvList, {}, SPINDLE_LOC_STR ":$TMPDIR/:/proc/:/dev/:/var/:/tmp/",
      "Colon-seperated list of directories that spindle will not cache files out of" },
    { confDebug, "debug", shortDebug, groupMisc, cvBool, {}, "false",
      "If yes, hide spindle from debuggers so they think libraries come from the original locations.  May cause extra overhead." },

--- a/src/flux/flux-spindle.c
+++ b/src/flux/flux-spindle.c
@@ -132,10 +132,22 @@ static void spindle_ctx_destroy (struct spindle_ctx *ctx)
     }
 }
 
+static void onTermSignal(int sig)
+{
+   //Force an exit in the child.
+   spindleForceExitBE();
+
+   //Reset the signal handlers and rethrow the signal. 
+   signal(SIGINT, SIG_DFL);
+   signal(SIGTERM, SIG_DFL);
+   kill(getpid(), sig);
+}
+
 /*  Run spindle backend as a child of the shell
  */
 static int run_spindle_backend (struct spindle_ctx *ctx)
 {
+    enableSpindleForceExitBE();
     ctx->backend_pid = fork ();
     if (ctx->backend_pid == 0) {
         /* N.B.: spindleRunBE() blocks, which is why we run it in a child
@@ -145,8 +157,8 @@ static int run_spindle_backend (struct spindle_ctx *ctx)
          * Note: this is a stopgap measure for now. Eventually the Flux
          * job shell will automate this step with an atfork handler.
          */
-        signal (SIGINT, SIG_DFL);
-        signal (SIGTERM, SIG_DFL);
+        signal(SIGINT, onTermSignal);
+        signal(SIGTERM, onTermSignal);
 
         if (spindleRunBE (ctx->params.port,
                           ctx->params.num_ports,

--- a/src/include/spindle_launch.h
+++ b/src/include/spindle_launch.h
@@ -230,6 +230,16 @@ SPINDLE_EXPORT int spindleHookSpindleArgsIntoExecBE(int spindle_argc, char **spi
    and with the 'location' from the spindle_args_t. */
 SPINDLE_EXPORT int spindleExitBE(const char *location);
 
+/* Sets up spindle to be responsive to spindleForceExit(). This function should be called before spindleRunBE().
+ */
+SPINDLE_EXPORT int enableSpindleForceExitBE();
+   
+/* Forcefully trigger an exit of the spindle be processes. The filesystem will be cleaned up, but the
+   server will disconnect from the spindle network and clients without regard for them continuing to be run.
+   Should only be used during a forceful job termincation. This call should be made by whichever process calls
+   enableForceExit. It is safe to call this function from a signal handler.
+*/
+SPINDLE_EXPORT int spindleForceExitBE();
 
 /* Adds output to spindle's debug loggging, if enabled, using printf-style interface.
    priority can be 1, 2, or 3.  More-verbose debugging output should be a higher 

--- a/src/logging/spindle_logd.cc
+++ b/src/logging/spindle_logd.cc
@@ -268,14 +268,15 @@ public:
           strstr(filename, ".py") == NULL)
          return true;
       bool is_from_temp = (strstr(filename, tmp_dir.c_str()) != NULL) && (strncmp(filename, "/__not_exist", 12) != 0);
+      bool is_local_test = strstr(filename, "liblocal") != NULL;
 
-      if (is_from_temp && ret_code == -1) {
+      if (is_from_temp && !is_local_test && ret_code == -1) {
          std::string msg = std::string("Error: Failed to load from ramdisk: ") + std::string(filename);
          logerror(msg);
          return false;
       }
       
-      if (!is_from_temp && ret_code != -1 && strstr(filename, "libc.so") == NULL) {
+      if (!is_from_temp && !is_local_test && ret_code != -1 && strstr(filename, "libc.so") == NULL) {
          std::string msg = std::string("Error: Read shared object from outside cache: ") + std::string(filename) + "\n";
          logerror(msg);
          return false;

--- a/src/server/auditserver/Makefile.am
+++ b/src/server/auditserver/Makefile.am
@@ -5,7 +5,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/comlib -I$(top_srcdir)/cache -I$(top_srcdir)/../co
 LDADD = $(top_builddir)/cache/libldcs_cache.la -lrt
 #AM_LDFLAGS = -all-static
 
-libserverbase_la_SOURCES = ldcs_audit_server_client_cb.c ldcs_audit_server_server_cb.c ldcs_audit_server_process.c ldcs_audit_server_filemngt.c ldcs_audit_server_handlers.c ldcs_elf_read.c ldcs_audit_server_requestors.c ldcs_audit_server_numa.c msgbundle.c parse_mounts.cc cleanup_proc.cc translate_maps.c
+libserverbase_la_SOURCES = ldcs_audit_server_client_cb.c ldcs_audit_server_server_cb.c ldcs_audit_server_process.c ldcs_audit_server_filemngt.c ldcs_audit_server_handlers.c ldcs_elf_read.c ldcs_audit_server_requestors.c ldcs_audit_server_numa.c msgbundle.c parse_mounts.cc cleanup_proc.cc translate_maps.c force_exit.c
 libserverbase_la_LIBADD = -lpthread
 
 #libaudit_server_msocket_la_SOURCES = ldcs_audit_server_md_msocket.c ldcs_audit_server_md_msocket_util.c ldcs_audit_server_md_msocket_topo.c 

--- a/src/server/auditserver/Makefile.in
+++ b/src/server/auditserver/Makefile.in
@@ -124,7 +124,7 @@ am_libserverbase_la_OBJECTS = ldcs_audit_server_client_cb.lo \
 	ldcs_audit_server_filemngt.lo ldcs_audit_server_handlers.lo \
 	ldcs_elf_read.lo ldcs_audit_server_requestors.lo \
 	ldcs_audit_server_numa.lo msgbundle.lo parse_mounts.lo \
-	cleanup_proc.lo translate_maps.lo
+	cleanup_proc.lo translate_maps.lo force_exit.lo
 libserverbase_la_OBJECTS = $(am_libserverbase_la_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -142,6 +142,7 @@ DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)
 depcomp = $(SHELL) $(top_srcdir)/../../scripts/depcomp
 am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = ./$(DEPDIR)/cleanup_proc.Plo \
+	./$(DEPDIR)/force_exit.Plo \
 	./$(DEPDIR)/ldcs_audit_server_client_cb.Plo \
 	./$(DEPDIR)/ldcs_audit_server_filemngt.Plo \
 	./$(DEPDIR)/ldcs_audit_server_handlers.Plo \
@@ -376,7 +377,7 @@ noinst_LTLIBRARIES = libaudit_server_cobo.la libserverbase.la
 AM_CPPFLAGS = -I$(top_srcdir)/comlib -I$(top_srcdir)/cache -I$(top_srcdir)/../cobo -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/../utils -DLIBEXECDIR=\"$(pkglibexecdir)\"
 LDADD = $(top_builddir)/cache/libldcs_cache.la -lrt
 #AM_LDFLAGS = -all-static
-libserverbase_la_SOURCES = ldcs_audit_server_client_cb.c ldcs_audit_server_server_cb.c ldcs_audit_server_process.c ldcs_audit_server_filemngt.c ldcs_audit_server_handlers.c ldcs_elf_read.c ldcs_audit_server_requestors.c ldcs_audit_server_numa.c msgbundle.c parse_mounts.cc cleanup_proc.cc translate_maps.c
+libserverbase_la_SOURCES = ldcs_audit_server_client_cb.c ldcs_audit_server_server_cb.c ldcs_audit_server_process.c ldcs_audit_server_filemngt.c ldcs_audit_server_handlers.c ldcs_elf_read.c ldcs_audit_server_requestors.c ldcs_audit_server_numa.c msgbundle.c parse_mounts.cc cleanup_proc.cc translate_maps.c force_exit.c
 libserverbase_la_LIBADD = -lpthread
 
 #libaudit_server_msocket_la_SOURCES = ldcs_audit_server_md_msocket.c ldcs_audit_server_md_msocket_util.c ldcs_audit_server_md_msocket_topo.c 
@@ -443,6 +444,7 @@ distclean-compile:
 	-rm -f *.tab.c
 
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/cleanup_proc.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/force_exit.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ldcs_audit_server_client_cb.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ldcs_audit_server_filemngt.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/ldcs_audit_server_handlers.Plo@am__quote@ # am--include-marker
@@ -642,6 +644,7 @@ clean-am: clean-generic clean-libtool clean-noinstLTLIBRARIES \
 
 distclean: distclean-am
 		-rm -f ./$(DEPDIR)/cleanup_proc.Plo
+	-rm -f ./$(DEPDIR)/force_exit.Plo
 	-rm -f ./$(DEPDIR)/ldcs_audit_server_client_cb.Plo
 	-rm -f ./$(DEPDIR)/ldcs_audit_server_filemngt.Plo
 	-rm -f ./$(DEPDIR)/ldcs_audit_server_handlers.Plo
@@ -700,6 +703,7 @@ installcheck-am:
 
 maintainer-clean: maintainer-clean-am
 		-rm -f ./$(DEPDIR)/cleanup_proc.Plo
+	-rm -f ./$(DEPDIR)/force_exit.Plo
 	-rm -f ./$(DEPDIR)/ldcs_audit_server_client_cb.Plo
 	-rm -f ./$(DEPDIR)/ldcs_audit_server_filemngt.Plo
 	-rm -f ./$(DEPDIR)/ldcs_audit_server_handlers.Plo

--- a/src/server/auditserver/force_exit.c
+++ b/src/server/auditserver/force_exit.c
@@ -1,0 +1,111 @@
+/*
+This file is part of Spindle.  For copyright information see the COPYRIGHT 
+file in the top level directory, or at 
+https://github.com/hpc/Spindle/blob/master/COPYRIGHT
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License (as published by the Free Software
+Foundation) version 2.1 dated February 1999.  This program is distributed in the
+hope that it will be useful, but WITHOUT ANY WARRANTY; without even the IMPLIED
+WARRANTY OF MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms 
+and conditions of the GNU Lesser General Public License for more details.  You should 
+have received a copy of the GNU Lesser General Public License along with this 
+program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#define _GNU_SOURCE
+#include <unistd.h>
+#include <errno.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+#include "spindle_debug.h"
+#include "ldcs_audit_server_filemngt.h"
+#include "ldcs_api_listen.h"
+#include "ldcs_audit_server_process.h"
+
+static int enabled = 0;
+static int fds[2];
+static pid_t register_pid;
+#define RD 0
+#define WR 1
+
+/**
+ * Public API function. Sets up a pipe to communicate a forceExit.
+ **/
+int enableSpindleForceExitBE()
+{
+   int result;
+   result = pipe2(fds, O_NONBLOCK);
+   if (result == -1) {
+      err_printf("Unable to create pipe fds for force exit\n");
+      return -1;
+   }
+   enabled = 1;
+   register_pid = getpid();
+   return 0;
+}
+
+/**
+ * Public API function. Triggers a byte on the forceExit pipe, which will be interpreted by the ldcs_listen
+ * infrastructure as a signal to terminate.
+ **/
+int spindleForceExitBE()
+{
+   int result;
+   int error, savederr;
+   if (!enabled)
+      return -1;
+
+   savederr = errno;
+
+   debug_printf("Asked to force exit on BE\n");
+   result = write(fds[WR], "x", 1);
+   if (result == -1) {
+      error = errno;
+      err_printf("Unable to write to force exit file descriptor: %s\n", strerror(error));
+      errno = savederr;
+      return -1;
+   }
+   errno = savederr;
+   return 0;
+}
+
+/**
+ * The fd returned from this function will 
+ **/
+int getForceExitFd()
+{
+   if (!enabled)
+      return -1;
+   if (fds[WR] != -1 && getpid() != register_pid) {
+      debug_printf("Clearing write part of exitfd, which was started on other pid %d (I am %d)\n", register_pid, getpid());
+      close(fds[WR]);
+      fds[WR] = -1;
+   }
+   return fds[RD];
+}
+
+extern int set_exit_on_client_close(ldcs_process_data_t *procdata);
+int forceExitCB(int fd, int serverid, void *data)
+{
+   char c;
+   int result;
+   ldcs_process_data_t *procdata = (ldcs_process_data_t *) data;
+   if (!enabled)
+      return 0;
+   result = read(fd, &c, 1);
+   if (result != 1) {
+      debug_printf("No bytes read from force exit pipe. Setting to exit when ready\n");
+      set_exit_on_client_close(procdata);
+      return 0;
+   }
+   if (c != 'x') {
+      debug_printf("forceExitCB had incorrect character in it: %c (%d)\n", c, (int) c);      
+   }
+   debug_printf("Exiting server through force exit\n");
+   ldcs_audit_server_filemngt_clean();
+   exit(0);
+   return 0;
+}

--- a/src/server/auditserver/force_exit.h
+++ b/src/server/auditserver/force_exit.h
@@ -14,18 +14,18 @@ program; if not, write to the Free Software Foundation, Inc., 59 Temple
 Place, Suite 330, Boston, MA 02111-1307 USA
 */
 
-#ifndef LDCS_AUDIT_SERVER_STATELOOP_H
-#define LDCS_AUDIT_SERVER_STATELOOP_H
+#if !defined(FORCE_EXIT_H_)
+#define FORCE_EXIT_H_
 
-#include "ldcs_audit_server_process.h"
-#include "ldcs_audit_server_md.h"
+#if defined(__cplusplus)
+extern "C" {
+#endif
+   
+int getForceExitFd();
+int forceExitCB(int fd, int serverid, void *data);
 
-int handle_server_message(ldcs_process_data_t *procdata, node_peer_t peer, ldcs_message_t *msg);
-int handle_server_error(ldcs_process_data_t *procdata, node_peer_t peer);
-int handle_client_message(ldcs_process_data_t *procdata, int nc, ldcs_message_t *msg);
-int handle_client_start(ldcs_process_data_t *procdata, int nc);
-int handle_client_end(ldcs_process_data_t *procdata, int nc);
-int exit_note_cb(int infd, int serverid, void *data);
-
+#if defined(__cplusplus)
+}
+#endif
 
 #endif

--- a/src/server/auditserver/ldcs_audit_server_handlers.c
+++ b/src/server/auditserver/ldcs_audit_server_handlers.c
@@ -1898,6 +1898,18 @@ static int handle_msgbundle(ldcs_process_data_t *procdata, node_peer_t peer, ldc
 }
 
 /**
+ * A parent or child server in the md tree exited.
+ **/
+int handle_server_error(ldcs_process_data_t *procdata, node_peer_t peer)
+{
+   if (ldcs_audit_server_md_is_parent(peer))
+      procdata->num_exited_parents++;
+   else
+      procdata->num_exited_children_peers++;
+   return 0;
+}
+
+/**
  * Handle a message that just arrived from a server
  **/
 int handle_server_message(ldcs_process_data_t *procdata, node_peer_t peer, ldcs_message_t *msg)
@@ -2862,12 +2874,12 @@ static int handle_send_exit_ready_if_done(ldcs_process_data_t *procdata)
       stopprofile();
    }
    
-   if (procdata->opts & OPT_PERSIST) {
+   if (procdata->opts & OPT_PERSIST && !procdata->exit_on_client_close) {
        debug_printf2("Bottom-up exit has been disabled\n");
        return 0;
    }
 
-   if (procdata->sent_exit_ready) {
+   if (procdata->sent_exit_ready && !procdata->num_exited_parents) {
       debug_printf2("Already sent an exit message.  Not sending another\n");
       return 0;
    }
@@ -2877,13 +2889,18 @@ static int handle_send_exit_ready_if_done(ldcs_process_data_t *procdata)
       return 0;
    }
 
-   if ((procdata->opts & OPT_BEEXIT) && (!procdata->exit_note_done)) {
+   if ((procdata->opts & OPT_BEEXIT) && (!procdata->exit_note_done) && (!procdata->exit_on_client_close)) {
       debug_printf2("BE Exit enable, and not signaled with spindleExitBE.  Not exiting\n");
       return 0;
    }
    
    int num_children = ldcs_audit_server_md_get_num_children(procdata);
-   if (procdata->exit_readys_recvd < num_children) {
+   if (procdata->num_exited_children_peers < num_children)
+      num_children -= procdata->num_exited_children_peers;
+   else
+      num_children = 0;
+   
+   if (procdata->exit_readys_recvd < num_children && !procdata->exit_on_client_close) {
       debug_printf2("Not all child servers are ready to exit.\n");
       return 0;
    }
@@ -3000,4 +3017,17 @@ int exit_note_cb(int fd, int serverid, void *data)
    ldcs_listen_unregister_fd(fd);
    
    return eresult;
+}
+
+int set_exit_on_client_close(ldcs_process_data_t *procdata)
+{
+   int result;
+   debug_printf("Marking spindle to exit after last client closes\n");
+   procdata->exit_on_client_close = 1;
+   result = handle_send_exit_ready_if_done(procdata);
+   if (result == -1) {
+      debug_printf("Failure in handle_send_exit_ready_if_done\n");
+      return -1;
+   }
+   return 0;
 }

--- a/src/server/auditserver/ldcs_audit_server_md.h
+++ b/src/server/auditserver/ldcs_audit_server_md.h
@@ -106,6 +106,8 @@ int ldcs_audit_server_md_broadcast_noncontig(ldcs_process_data_t *ldcs_process_d
 
 int ldcs_audit_server_md_get_num_children(ldcs_process_data_t *procdata);
 
+int ldcs_audit_server_md_is_parent(node_peer_t peer);
+   
 #if defined(__cplusplus)
 }
 #endif

--- a/src/server/auditserver/ldcs_audit_server_md_cobo.c
+++ b/src/server/auditserver/ldcs_audit_server_md_cobo.c
@@ -261,11 +261,24 @@ int ldcs_audit_server_md_trash_bytes(node_peer_t peer, size_t size)
 
 int ldcs_audit_server_md_recv_from_parent(ldcs_message_t *msg)
 {
-   int fd;
+   int fd, rc;
    node_peer_t peer;
 
    cobo_get_parent_socket(&fd);
-   return read_msg(fd, &peer, msg);
+   rc = read_msg(fd, &peer, msg);
+   if (rc == -1) {
+      debug_printf2("Error return during recv from parent.\n");
+      return -1;
+   }
+   return 0;
+}
+
+int ldcs_audit_server_md_is_parent(node_peer_t peer)
+{
+   int fd = -1, peer_fd;
+   cobo_get_parent_socket(&fd);
+   peer_fd = (int) (long) peer;
+   return peer_fd == fd;
 }
 
 int ldcs_audit_server_md_cobo_CB(int fd, int nc, void *data)
@@ -278,8 +291,11 @@ int ldcs_audit_server_md_cobo_CB(int fd, int nc, void *data)
   
    /* receive msg from cobo network */
    rc = read_msg(fd, &peer, &msg);
-   if (rc == -1)
+   if (rc == -1) {
+      debug_printf2("Error return during recv from peer.\n");
+      rc = handle_server_error(ldcs_process_data, peer);
       return -1;
+   }
 
    rc = handle_server_message(ldcs_process_data, peer, &msg);
 

--- a/src/server/auditserver/ldcs_audit_server_process.c
+++ b/src/server/auditserver/ldcs_audit_server_process.c
@@ -162,6 +162,9 @@ int ldcs_audit_server_process(spindle_args_t *args)
    ldcs_process_data.completed_ldso_requests = new_requestor_list();
    ldcs_process_data.handling_bundle = 0;
    ldcs_process_data.exit_note_done = 0;
+   ldcs_process_data.exit_on_client_close = 0;
+   ldcs_process_data.num_exited_children_peers = 0;
+   ldcs_process_data.num_exited_parents = 0;
    
    if (ldcs_process_data.opts & OPT_PULL) {
       debug_printf("Using PULL model\n");
@@ -219,6 +222,10 @@ int ldcs_audit_server_process(spindle_args_t *args)
 
    msgbundle_init(&ldcs_process_data);
 
+   fd = getForceExitFd();
+   if (fd != -1) {
+      ldcs_listen_register_fd(fd, serverid, forceExitCB, (void *) &ldcs_process_data);
+   }
    return 0;
 }  
 

--- a/src/server/auditserver/ldcs_audit_server_process.h
+++ b/src/server/auditserver/ldcs_audit_server_process.h
@@ -24,7 +24,8 @@ extern "C" {
 #include "ldcs_api.h"
 #include "spindle_launch.h"
 #include "stat_cache.h"   
-
+#include "force_exit.h"
+   
 typedef void* requestor_list_t;
 
 /* client description structure */
@@ -137,6 +138,9 @@ struct ldcs_process_data_struct
   int number;
   int preload_done;
   int exit_note_done;
+  int exit_on_client_close;
+  int num_exited_children_peers;
+  int num_exited_parents;
   opt_t opts;
   requestor_list_t dso_requests;
   requestor_list_t file_requests;   
@@ -148,7 +152,7 @@ struct ldcs_process_data_struct
   requestor_list_t completed_lstat_requests;
   requestor_list_t pending_ldso_requests;
   requestor_list_t completed_ldso_requests;
-
+   
   /* multi daemon support */
   int md_rank;
   int md_size;

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -1,7 +1,7 @@
 noinst_PROGRAMS = libgenerator
 
 ABS_TEST_DIR = $(abspath $(top_builddir)/testsuite)
-BUILT_SOURCES = libtest10.so libtest11.so libtest12.so libtest13.so libtest14.so libtest15.so libtest16.so libtest17.so libtest18.so libtest19.so libtest20.so libtest50.so libtest100.so libtest500.so libtest1000.so libtest2000.so libtest4000.so libtest6000.so libtest8000.so libtest10000.so libtls1.c libtls2.c libtls3.c libtls4.c libtls5.c libtls6.c libtls7.c libtls8.c libtls9.c libtls10.c libtls11.c libtls12.c libtls13.c libtls14.c libtls15.c libtls16.c libtls17.c libtls18.c libtls19.c libtls20.c libsymlink.so libdepC.so libdepB.so libdepA.so libcxxexceptB.so libcxxexceptA.so origin_dir/liboriginlib.so origin_dir/origin_subdir/liborigintarget.so libtestoutput.so libfuncdict.so runTests run_driver run_driver_rm spindle.rc preload_file_list test_driver test_driver_libs retzero_rx retzero_r retzero_x retzero_ badinterp hello_r.py hello_x.py hello_rx.py hello_.py hello_l.py badlink.py spindle_exec_test spindle_deactivated.sh
+BUILT_SOURCES = libtest10.so libtest11.so libtest12.so libtest13.so libtest14.so libtest15.so libtest16.so libtest17.so libtest18.so libtest19.so libtest20.so libtest50.so libtest100.so libtest500.so libtest1000.so libtest2000.so libtest4000.so libtest6000.so libtest8000.so libtest10000.so libtls1.c libtls2.c libtls3.c libtls4.c libtls5.c libtls6.c libtls7.c libtls8.c libtls9.c libtls10.c libtls11.c libtls12.c libtls13.c libtls14.c libtls15.c libtls16.c libtls17.c libtls18.c libtls19.c libtls20.c libsymlink.so libdepC.so libdepB.so libdepA.so libcxxexceptB.so libcxxexceptA.so origin_dir/liboriginlib.so origin_dir/origin_subdir/liborigintarget.so libtestoutput.so libfuncdict.so runTests run_driver run_driver_rm spindle.rc preload_file_list test_driver test_driver_libs retzero_rx retzero_r retzero_x retzero_ badinterp hello_r.py hello_x.py hello_rx.py hello_.py hello_l.py badlink.py spindle_exec_test spindle_deactivated.sh liblocal.so
 
 if BGQ_BLD
 DYNAMIC_FLAG=-dynamic
@@ -274,6 +274,9 @@ libtls20.so: libtls20.c $(REGLIB_SRC) libfuncdict.so
 
 libdepA.so: libdepA.c $(REGLIB_SRC) libdepB.so libfuncdict.so
 	$(AM_V_CCLD)$(MPICC) -o $@ -fPIC -Wall $< $(REGLIB_SRC) -shared -L. -ldepB -DSO_NAME=$@ -DFUNC_NAME=depA_calc  $(LD_FUNCDICT)
+
+liblocal.so: local.c $(REGLIB_SRC) libfuncdict.so
+	$(AM_V_CCLD)$(MPICC) -o $@ -fPIC -Wall $< $(REGLIB_SRC) -shared $(LD_FUNCDICT) -DSO_NAME=$@ -DFUNC_NAME=check_hostname 
 
 libsymlink.so: libtest10.so
 	$(AM_V_GEN) ln -fs $< $@

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -337,7 +337,7 @@ top_build_prefix = @top_build_prefix@
 top_builddir = @top_builddir@
 top_srcdir = @top_srcdir@
 ABS_TEST_DIR = $(abspath $(top_builddir)/testsuite)
-BUILT_SOURCES = libtest10.so libtest11.so libtest12.so libtest13.so libtest14.so libtest15.so libtest16.so libtest17.so libtest18.so libtest19.so libtest20.so libtest50.so libtest100.so libtest500.so libtest1000.so libtest2000.so libtest4000.so libtest6000.so libtest8000.so libtest10000.so libtls1.c libtls2.c libtls3.c libtls4.c libtls5.c libtls6.c libtls7.c libtls8.c libtls9.c libtls10.c libtls11.c libtls12.c libtls13.c libtls14.c libtls15.c libtls16.c libtls17.c libtls18.c libtls19.c libtls20.c libsymlink.so libdepC.so libdepB.so libdepA.so libcxxexceptB.so libcxxexceptA.so origin_dir/liboriginlib.so origin_dir/origin_subdir/liborigintarget.so libtestoutput.so libfuncdict.so runTests run_driver run_driver_rm spindle.rc preload_file_list test_driver test_driver_libs retzero_rx retzero_r retzero_x retzero_ badinterp hello_r.py hello_x.py hello_rx.py hello_.py hello_l.py badlink.py spindle_exec_test spindle_deactivated.sh
+BUILT_SOURCES = libtest10.so libtest11.so libtest12.so libtest13.so libtest14.so libtest15.so libtest16.so libtest17.so libtest18.so libtest19.so libtest20.so libtest50.so libtest100.so libtest500.so libtest1000.so libtest2000.so libtest4000.so libtest6000.so libtest8000.so libtest10000.so libtls1.c libtls2.c libtls3.c libtls4.c libtls5.c libtls6.c libtls7.c libtls8.c libtls9.c libtls10.c libtls11.c libtls12.c libtls13.c libtls14.c libtls15.c libtls16.c libtls17.c libtls18.c libtls19.c libtls20.c libsymlink.so libdepC.so libdepB.so libdepA.so libcxxexceptB.so libcxxexceptA.so origin_dir/liboriginlib.so origin_dir/origin_subdir/liborigintarget.so libtestoutput.so libfuncdict.so runTests run_driver run_driver_rm spindle.rc preload_file_list test_driver test_driver_libs retzero_rx retzero_r retzero_x retzero_ badinterp hello_r.py hello_x.py hello_rx.py hello_.py hello_l.py badlink.py spindle_exec_test spindle_deactivated.sh liblocal.so
 @BGQ_BLD_FALSE@DYNAMIC_FLAG = 
 @BGQ_BLD_TRUE@DYNAMIC_FLAG = -dynamic
 @BGQ_BLD_FALSE@IS_BLUEGENE = false
@@ -927,6 +927,9 @@ libtls20.so: libtls20.c $(REGLIB_SRC) libfuncdict.so
 
 libdepA.so: libdepA.c $(REGLIB_SRC) libdepB.so libfuncdict.so
 	$(AM_V_CCLD)$(MPICC) -o $@ -fPIC -Wall $< $(REGLIB_SRC) -shared -L. -ldepB -DSO_NAME=$@ -DFUNC_NAME=depA_calc  $(LD_FUNCDICT)
+
+liblocal.so: local.c $(REGLIB_SRC) libfuncdict.so
+	$(AM_V_CCLD)$(MPICC) -o $@ -fPIC -Wall $< $(REGLIB_SRC) -shared $(LD_FUNCDICT) -DSO_NAME=$@ -DFUNC_NAME=check_hostname 
 
 libsymlink.so: libtest10.so
 	$(AM_V_GEN) ln -fs $< $@

--- a/testsuite/local.c
+++ b/testsuite/local.c
@@ -1,0 +1,23 @@
+#include <unistd.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+char placeholder[256] =
+"SPINDLE_PLACEHOLDERxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx";
+
+int check_hostname()
+{
+   char hostname[256];
+   memset(hostname, 0, sizeof(hostname));
+   gethostname(hostname, sizeof(hostname));
+   hostname[sizeof(hostname)-1] = '\0';
+
+   if (strcmp(placeholder, hostname) != 0) {
+      fprintf(stderr, "ERROR: Problem during liblocal test, placeholder name did not match hostname: %s != %s\n",
+              placeholder, hostname);
+      return 0;
+   }
+   return 1;
+}
+

--- a/testsuite/test_driver.c
+++ b/testsuite/test_driver.c
@@ -109,6 +109,7 @@ typedef struct {
 #define FLAGS_WONTLOAD (1 << 4)
 #define FLAGS_TLSLIB   (1 << 5)
 #define FLAGS_CHECKSYMT (1 << 6)
+#define FLAGS_LOCAL (1 << 7)
 int abort_mode = 0;
 int fork_mode = 0;
 int fork_child = 0;
@@ -192,7 +193,8 @@ open_libraries_t libraries[] = {
    { "libtest4000.so", NULL, NULL, NULL, UNLOADED, FLAGS_CHECKSYMT | FLAGS_SKIP, NULL },
    { "libtest6000.so", NULL, NULL, NULL, UNLOADED, FLAGS_CHECKSYMT | FLAGS_SKIP, NULL },
    { "libtest8000.so", NULL, NULL, NULL, UNLOADED, FLAGS_CHECKSYMT | FLAGS_SKIP, NULL },
-   { "libtest10000.so", NULL, NULL, NULL, UNLOADED, FLAGS_CHECKSYMT | FLAGS_SKIP, NULL },   
+   { "libtest10000.so", NULL, NULL, NULL, UNLOADED, FLAGS_CHECKSYMT | FLAGS_SKIP, NULL },
+   { "liblocal.so", NULL, NULL, NULL, UNLOADED, FLAGS_LOCAL, NULL },
    { NULL, NULL, NULL, 0, 0 }
 };
 int num_libraries;
@@ -317,17 +319,151 @@ static void check_symt(char *path)
     */
 }
 
+static char *get_local_name(int libnum, char *out, int out_size)
+{
+   char *tmpdir;
+   char tmp[MAX_STR_SIZE];
+
+   tmpdir = getenv("TMPDIR");
+   if (!tmpdir)
+      tmpdir = getenv("TMP");
+   if (!tmpdir)
+      tmpdir = "/tmp";
+
+   realpath(tmpdir, tmp);
+
+   snprintf(out, out_size, "%s/%s", tmp, libraries[libnum].libname);
+   out[out_size-1] = '\0';
+   return out;
+}
+
+static void clean_local_libs()
+{
+   char out_filename[MAX_STR_SIZE];
+   int i;
+
+   for (i = 0; libraries[i].libname; i++) {
+      get_local_name(i, out_filename, sizeof(out_filename));
+      unlink(out_filename);
+   }
+}
+
+static char *create_local_file(int libnum)
+{
+   static char out_filename[MAX_STR_SIZE];
+   char hostname[256];
+   char *in_filename, *result_filename = NULL;
+   char *contents = MAP_FAILED;
+   int in_fd = -1, out_fd = -1;
+   int result, i, found = 0;
+   size_t in_size;
+   struct stat statbuf;
+   int timeout = 50;
+   const char *key = "SPINDLE_PLACEHOLDER";
+
+   memset(hostname, 0, sizeof(hostname));
+   gethostname(hostname, sizeof(hostname)-1);
+
+   in_filename = libpath(libraries[libnum].libname, libraries[libnum].subdir);
+   in_fd = open(in_filename, O_RDONLY);
+   if (in_fd == -1) {
+      err_printf("Failed to open %s\n", in_filename);
+      goto done;
+   }
+   result = fstat(in_fd, &statbuf);
+   if (result == -1) {
+      err_printf("Failed to stat %s\n", in_filename);
+      goto done;
+   }
+   in_size = statbuf.st_size;
+
+   contents = (char *) mmap(NULL, in_size, PROT_READ | PROT_WRITE, MAP_PRIVATE, in_fd, 0);
+   if (contents == MAP_FAILED) {
+      err_printf("Failed to mmap %s\n", in_filename);
+      goto done;
+   }
+
+   for (i = 0; i < in_size - strlen(key); i++) {
+      if (contents[i] != key[0])
+         continue;
+      if (contents[i+1] != key[1])
+         continue;
+      if (contents[i+2] != key[2])
+         continue;
+      if (strncmp(contents+i, key, strlen(key)) == 0) {
+         strncpy(contents+i, hostname, in_size - i);
+         found = 1;
+         break;
+      }
+   }
+   if (!found) {
+      err_printf("Failed to find placeholder in %s\n", in_filename);
+      goto done;
+   }
+
+   get_local_name(libnum, out_filename, sizeof(out_filename));
+   out_fd = open(out_filename, O_WRONLY | O_CREAT | O_EXCL, S_IRWXU);
+   if (out_fd == -1 && errno != EEXIST) {
+      err_printf("Failed to open output file %s\n", out_filename);
+      goto done;
+   }
+   if (out_fd != -1) {
+      i = 0;
+      do {
+         result = write(out_fd, contents+i, in_size-i);
+         if (result == -1 && errno == EINTR) {
+            continue;
+         }
+         else if (result == -1) {
+            err_printf("Failed to write to %s", out_filename);
+            goto done;
+         }
+         i += result;
+      } while (i < in_size);
+      close(out_fd);
+      out_fd = -1;
+   }
+
+   while (timeout > 0) {
+      int result = stat(out_filename, &statbuf);
+      if (result == 0 && statbuf.st_size == in_size)
+         break;
+      usleep(1000);
+      timeout--;
+   }
+   if (!timeout) {
+      err_printf("Timed out waiting for %s to be created and reach proper size\n", out_filename);
+      goto done;
+   }
+
+   result_filename = out_filename;
+
+  done:
+   if (contents != MAP_FAILED)
+      munmap(contents, in_size);
+   if (in_fd != -1)
+      close(in_fd);
+   if (out_fd != -1)
+      close(out_fd);
+   return result_filename;
+}
+
+
 static void open_library(int i)
 {
    char *fullpath, *result;
    if (libraries[i].flags & FLAGS_TLSLIB)
       return;
-   fullpath = libpath(libraries[i].libname, libraries[i].subdir);
+   if (!(libraries[i].flags & FLAGS_LOCAL))
+      fullpath = libpath(libraries[i].libname, libraries[i].subdir);
+   else
+      fullpath = create_local_file(i);
+   
    if (libraries[i].flags & FLAGS_CHECKSYMT) {
       check_symt(fullpath);
       return;
    }   
-   if (!(libraries[i].flags & FLAGS_WONTLOAD))
+   if (!(libraries[i].flags & FLAGS_WONTLOAD) && !(libraries[i].flags & FLAGS_LOCAL))
       test_printf("dlstart %s\n", libraries[i].libname);
    
    result = dlopen(fullpath, RTLD_LAZY | RTLD_GLOBAL);
@@ -365,7 +501,9 @@ void dependency_mode()
    for (i = 0; i<num_libraries; i++) {
       if (libraries[i].flags & FLAGS_CHECKSYMT)
          open_library(i);
-      if (libraries[i].flags & FLAGS_NOEXIST || libraries[i].flags & FLAGS_SKIP || libraries[i].flags & FLAGS_WONTLOAD)
+      if (libraries[i].flags & FLAGS_LOCAL)
+         open_library(i);
+      if (libraries[i].flags & FLAGS_NOEXIST || libraries[i].flags & FLAGS_SKIP || libraries[i].flags & FLAGS_WONTLOAD || libraries[i].flags & FLAGS_LOCAL)
          continue;
       libraries[i].opened = STARTUP_LOAD;
       test_printf("dlstart %s\n", libraries[i].libname);
@@ -383,7 +521,7 @@ void ldpreload_mode()
 
    dependency_mode();
    for (i = 0; i < num_libraries; i++) {
-      if (libraries[i].flags & FLAGS_NOEXIST || libraries[i].flags & FLAGS_SKIP)
+      if (libraries[i].flags & FLAGS_NOEXIST || libraries[i].flags & FLAGS_SKIP || libraries[i].flags & FLAGS_LOCAL)
          continue;
       if (strstr(env, libraries[i].libname) == NULL) {
          err_printf("Could not find library %s in LD_PRELOAD (%s)\n", libraries[i].libname, env);
@@ -847,7 +985,7 @@ void check_libraries()
           (!(libraries[i].flags & FLAGS_NOEXIST)) && 
           (!(libraries[i].flags & FLAGS_SKIP)) &&
           (!libraries[i].calc_func)) {
-         err_printf("Didn't open expected library %s\n", libraries[i].libname); 
+         err_printf("Didnocal't open expected library %s\n", libraries[i].libname); 
       }
       if (libraries[i].opened == UNLOADED)
          continue;
@@ -1231,6 +1369,7 @@ int main(int argc, char *argv[])
 
    if (!nompi_mode) {
 #if defined(HAVE_MPI)
+      clean_local_libs();
       result = MPI_Init(&argc, &argv);
       MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 #else
@@ -1254,8 +1393,10 @@ int main(int argc, char *argv[])
       passed = 0;
 
 #if defined(HAVE_MPI)
-   if (!nompi_mode)
+   if (!nompi_mode) {
       MPI_Finalize();
+      clean_local_libs();
+   }
 #endif
 
    if (rank == 0) {


### PR DESCRIPTION
Two separate issues fixed in this PR:

Handling for ctrl-c and other abnormal terminations added. Spindle now has a force-exit mode for shutdown. Unlike other shutdown methods, force-exit doesn't try to communicate on the spindle network to coordinate an exit. It should only trigger when things are going wrong, including spindle processes being terminated by ctrl-c. This mode must be enabled through the spindle_launch.h interface. The flux plugin enables this.

Add "/tmp" to the default list of local locations. We had $TMPDIR, but on some systems that pointed at the alias /var/tmp. rocm runtimes created libraries and loaded from /tmp, which wasn't properly identified as local because of the aliasing. Side-effects stemming from that caused faults in the rocm runtime. 