### PR TITLE
Fixes around running compilers under spindle

### DIFF
--- a/src/client/beboot/spindle_bootstrap.c
+++ b/src/client/beboot/spindle_bootstrap.c
@@ -320,6 +320,13 @@ int main(int argc, char *argv[])
       }
    }
 
+   if (isCompiler(cmdline[0])) {
+      debug_printf("Turning off spindle because we're running a compiler: %s\n", cmdline[0]);
+      execvp(cmdline[0], cmdline);
+      fprintf(stderr, "%s: Command not found.\n", cmdline[0]);
+      return -1;
+   }
+
    orig_location = parse_location(symbolic_location, number);
    if (!orig_location) {
       return -1;

--- a/src/client/client/exec_util.c
+++ b/src/client/client/exec_util.c
@@ -318,3 +318,35 @@ int read_buffer(char *localname, char *buffer, int size)
    close(fd);
    return 0;
 }
+
+static char* compilers[] = { "gcc", "g++", "cc", "CC", "clang", "clang++",
+                             "hipcc", "amdclang", "amdclang++",
+                             "craycc", "crayCC",
+                             "ld", "ld.lld",
+                             "mpicc", "mpic++", "mpicxx",
+                             "make", "gmake", NULL };
+
+                             
+int isCompiler(const char *fname)
+{
+   const char *aout = NULL;
+   const char *lastslash;
+   int i;
+
+   if (!fname)
+      return 0;
+   
+   lastslash = strrchr(fname, '/');
+   if (lastslash) 
+      aout = lastslash+1;
+   else
+      aout = fname;
+
+   for (i = 0; compilers[i] != NULL; i++) {
+      if (strcmp(compilers[i], aout) == 0) {
+         return 1;
+      }
+   }
+   return 0;
+}
+

--- a/src/client/client/exec_util.h
+++ b/src/client/client/exec_util.h
@@ -23,5 +23,6 @@
 
 int adjust_if_script(const char *orig_path, char *reloc_path, char **argv, char **interp_path, char ***new_argv);
 int exec_pathsearch(int ldcsid, const char *orig_exec, char **new_exec, int *errcode);
+int isCompiler(const char *fname);
 
 #endif

--- a/src/client/client/intercept_exec.c
+++ b/src/client/client/intercept_exec.c
@@ -60,36 +60,6 @@ static int strIsPrefix(char *prefix, char *str)
    return (strncmp(prefix, str, strlen(prefix)) == 0);
 }
 
-static char* compilers[] = { "gcc", "g++", "cc", "CC", "clang", "clang++",
-                             "hipcc", "amdclang", "amdclang++",
-                             "craycc", "crayCC",
-                             "ld", "ld.lld",
-                             "mpicc", "mpic++", "mpicxx", NULL };
-
-                             
-static int isCompiler(const char *fname)
-{
-   const char *aout = NULL;
-   const char *lastslash;
-   int i;
-
-   if (!fname)
-      return 0;
-   
-   lastslash = strrchr(fname, '/');
-   if (lastslash) 
-      aout = lastslash+1;
-   else
-      aout = fname;
-
-   for (i = 0; compilers[i] != NULL; i++) {
-      if (strcmp(compilers[i], aout) == 0) {
-         return 1;
-      }
-   }
-   return 0;
-}
-
 static int shouldPropogateSpindle(char **envp, const char *fname)
 {
    int i;

--- a/src/client/client/should_intercept.c
+++ b/src/client/client/should_intercept.c
@@ -122,12 +122,15 @@ int dlopen_filter(const char *pathname)
 
 static int is_lib_prefix(const char *pathname, char *last_slash)
 {
+   const char *filepart;
    if (last_slash && strncmp(last_slash, "/lib", 4) != 0)
       return 0;
    if (!last_slash && strncmp(pathname, "lib", 3) != 0)
       return 0;
    int len = strlen(pathname);
-   if (!strstr(last_slash, ".so.") && len > 3 && strncmp(pathname + len - 3, ".so", 3) != 0)
+
+   filepart = last_slash ? last_slash+1 : pathname;
+   if (!strstr(filepart, ".so.") && len > 3 && strncmp(pathname + len - 3, ".so", 3) != 0)
       return 0;
    return 1;
 }

--- a/src/flux/flux-spindle.c
+++ b/src/flux/flux-spindle.c
@@ -543,7 +543,7 @@ static int sp_exit (flux_plugin_t *p,
                     void *data)
 {
     struct spindle_ctx *ctx = flux_plugin_aux_get (p, "spindle");
-    if (ctx->params.opts & OPT_OFF)
+    if (ctx && ctx->params.opts & OPT_OFF)
        return 0;    
     if (ctx && ctx->shell_rank == 0)
         spindleCloseFE (&ctx->params);


### PR DESCRIPTION
A few small fixes all around running make/compilers/etc... under spindle:

- Fixes a crash in wildcard parsing in the client. Manifested when running 'mkdir -p libfoo' twice under spindle.
- Fix a crash in flux exit processing if spindle didn't run.
- Check the compiler-focused deny-list when running the top-level program. Adds make/gmake to the deny-list (the deny-list is the set of programs that spindle will not handle)