### PR TITLE
Fixes for abnormal termination under flux

### DIFF
--- a/src/client/client/exec_util.c
+++ b/src/client/client/exec_util.c
@@ -324,7 +324,7 @@ static char* compilers[] = { "gcc", "g++", "cc", "CC", "clang", "clang++",
                              "craycc", "crayCC",
                              "ld", "ld.lld",
                              "mpicc", "mpic++", "mpicxx",
-                             "make", "gmake", NULL };
+                             "make", "gmake", "cmake", NULL };
 
                              
 int isCompiler(const char *fname)

--- a/src/flux/flux-spindle.c
+++ b/src/flux/flux-spindle.c
@@ -7,6 +7,7 @@
 #include <stdio.h>
 #include <jansson.h>
 #include <strings.h>
+#include <unistd.h>
 
 #define FLUX_SHELL_PLUGIN_NAME "spindle"
 
@@ -135,31 +136,39 @@ static void spindle_ctx_destroy (struct spindle_ctx *ctx)
 static void onTermSignal(int sig)
 {
    //Force an exit in the child.
-   spindleForceExitBE();
+   spindleForceExitBE(SPINDLE_EXIT_TYPE_SOFT);
+   alarm(5); //Force shutdown in 5 seconds if not otherwise down
+}
 
-   //Reset the signal handlers and rethrow the signal. 
-   signal(SIGINT, SIG_DFL);
-   signal(SIGTERM, SIG_DFL);
-   kill(getpid(), sig);
+static void onAlarm(int sig)
+{
+   spindleForceExitBE(SPINDLE_EXIT_TYPE_HARD);
+   _exit(-1);
 }
 
 /*  Run spindle backend as a child of the shell
  */
 static int run_spindle_backend (struct spindle_ctx *ctx)
 {
-    enableSpindleForceExitBE();
+   sigset_t sset;
+
     ctx->backend_pid = fork ();
     if (ctx->backend_pid == 0) {
+       enableSpindleForceExitBE();
+
+       /* Set signal handlers for ctrl-c and related signals. */       
+       signal(SIGINT, onTermSignal);
+       signal(SIGTERM, onTermSignal);
+       signal(SIGALRM, onAlarm);
+       
+       sigprocmask(SIG_BLOCK, NULL, &sset);
+       sigdelset(&sset, SIGINT);
+       sigdelset(&sset, SIGTERM);
+       sigdelset(&sset, SIGALRM);
+       sigprocmask(SIG_SETMASK, &sset, NULL);
+
         /* N.B.: spindleRunBE() blocks, which is why we run it in a child
          */
-
-        /* Reset signal handlers in child, otherwise they are blocked.
-         * Note: this is a stopgap measure for now. Eventually the Flux
-         * job shell will automate this step with an atfork handler.
-         */
-        signal(SIGINT, onTermSignal);
-        signal(SIGTERM, onTermSignal);
-
         if (spindleRunBE (ctx->params.port,
                           ctx->params.num_ports,
                           ctx->id,

--- a/src/include/spindle_launch.h
+++ b/src/include/spindle_launch.h
@@ -234,12 +234,16 @@ SPINDLE_EXPORT int spindleExitBE(const char *location);
  */
 SPINDLE_EXPORT int enableSpindleForceExitBE();
    
-/* Forcefully trigger an exit of the spindle be processes. The filesystem will be cleaned up, but the
-   server will disconnect from the spindle network and clients without regard for them continuing to be run.
+/* Forcefully trigger an exit of the spindle be processes. 
+   If set to soft exit, spindle will trigger shutdown when its client and servers finish their last connection.
+   If hard exiting, spindle will clean its cache from the filesystem in expectation for the user to make
+   an exit call.
    Should only be used during a forceful job termincation. This call should be made by whichever process calls
    enableForceExit. It is safe to call this function from a signal handler.
 */
-SPINDLE_EXPORT int spindleForceExitBE();
+#define SPINDLE_EXIT_TYPE_SOFT 0
+#define SPINDLE_EXIT_TYPE_HARD 1
+SPINDLE_EXPORT int spindleForceExitBE(int exit_type);
 
 /* Adds output to spindle's debug loggging, if enabled, using printf-style interface.
    priority can be 1, 2, or 3.  More-verbose debugging output should be a higher 

--- a/src/server/auditserver/force_exit.c
+++ b/src/server/auditserver/force_exit.c
@@ -38,6 +38,7 @@ int enableSpindleForceExitBE()
 {
    int result;
    result = pipe2(fds, O_NONBLOCK);
+   debug_printf2("force exit pipe[RD] = %d and pipe[WR] = %d\n", fds[RD], fds[WR]);
    if (result == -1) {
       err_printf("Unable to create pipe fds for force exit\n");
       return -1;
@@ -48,27 +49,38 @@ int enableSpindleForceExitBE()
 }
 
 /**
- * Public API function. Triggers a byte on the forceExit pipe, which will be interpreted by the ldcs_listen
+ * Public API function. If soft exiting, Triggers a byte on the forceExit pipe, which will be interpreted by the ldcs_listen
  * infrastructure as a signal to terminate.
+ * If not soft exiting, just clean to prep for an exit call.
  **/
-int spindleForceExitBE()
+int spindleForceExitBE(int exit_type)
 {
    int result;
    int error, savederr;
-   if (!enabled)
-      return -1;
 
-   savederr = errno;
-
-   debug_printf("Asked to force exit on BE\n");
-   result = write(fds[WR], "x", 1);
-   if (result == -1) {
-      error = errno;
-      err_printf("Unable to write to force exit file descriptor: %s\n", strerror(error));
+   if (exit_type == SPINDLE_EXIT_TYPE_SOFT) {
+      if (!enabled)
+         return -1;
+      
+      savederr = errno;
+      
+      debug_printf("Asked to force exit on BE through fd %d\n", fds[WR]);
+      result = write(fds[WR], "x", 1);
+      if (result == -1) {
+         error = errno;
+         err_printf("Unable to write to force exit file descriptor: %s\n", strerror(error));
+         errno = savederr;
+         return -1;
+      }
       errno = savederr;
+   }
+   else if (exit_type == SPINDLE_EXIT_TYPE_HARD) {
+      debug_printf("Exiting server through force exit\n");
+      ldcs_audit_server_filemngt_clean();
+   }
+   else {
       return -1;
    }
-   errno = savederr;
    return 0;
 }
 
@@ -98,14 +110,12 @@ int forceExitCB(int fd, int serverid, void *data)
    result = read(fd, &c, 1);
    if (result != 1) {
       debug_printf("No bytes read from force exit pipe. Setting to exit when ready\n");
-      set_exit_on_client_close(procdata);
       return 0;
    }
    if (c != 'x') {
       debug_printf("forceExitCB had incorrect character in it: %c (%d)\n", c, (int) c);      
    }
-   debug_printf("Exiting server through force exit\n");
-   ldcs_audit_server_filemngt_clean();
-   exit(0);
+   debug_printf("Setting to exit when ready through force exit\n");
+   set_exit_on_client_close(procdata);
    return 0;
 }


### PR DESCRIPTION
Complications arose during abnormal terminations under flux. Under this PR we're unmasking the SIGTERM/SIGINT signals to work with newer flux versions. We're also better processing SIGTERM/SIGINT on the spindle server. As of this commit we're now doing a soft exit on receiving a SIGTERM/SIGINT, then setting a 5 second timeout before doing a hard exit.