### PR TITLE
Fix crash in liblocal test

### DIFF
--- a/testsuite/test_driver.c
+++ b/testsuite/test_driver.c
@@ -391,7 +391,7 @@ static char *create_local_file(int libnum)
       if (contents[i+2] != key[2])
          continue;
       if (strncmp(contents+i, key, strlen(key)) == 0) {
-         strncpy(contents+i, hostname, in_size - i);
+         strncpy(contents+i, hostname, sizeof(hostname)-1);
          found = 1;
          break;
       }


### PR DESCRIPTION
@rountree-alt found a crash from the new liblocal test, which we found to be from a bad strncpy that was writing too many zeros and corrupting the library it was in. 