### PR TITLE
Fix for printing proper error messages when running non-existant binaries under spindle

### DIFF
--- a/src/client/beboot/spindle_bootstrap.c
+++ b/src/client/beboot/spindle_bootstrap.c
@@ -46,7 +46,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 char spindle_daemon[] = LIBEXECDIR "/spindle_be";
 char spindle_interceptlib[] = PROGLIBDIR "/libspindleint.so";
 
-int ldcsid;
+int ldcsid = -1;
 unsigned int shm_cachesize;
 
 static int rankinfo[4]={-1,-1,-1,-1};
@@ -290,6 +290,35 @@ void test_log(const char *name)
 {
 }
 
+static int handle_exec_failure(char **cmdline, int errno_val)
+{
+   int result;
+   int one_per_job;
+   const char *errmsg;
+   const char *executable;
+   errmsg = strerror(errno_val);
+   executable = cmdline && cmdline[0] ? cmdline[0] : "[NULL]";
+   if (ldcsid == -1) {
+      debug_printf("Exec failure on %s without server setup: %s\n", executable, errmsg);
+      fprintf(stderr, "%s: %s\n", executable, errmsg);
+      return -1;
+   }
+
+   result = send_pickone_query(ldcsid, "bootstrap exec failure", &one_per_job);
+   if (result == -1) {
+      debug_printf("Exec and pickone failure on %s: %s\n", executable, errmsg);
+      fprintf(stderr, "%s: %s\n", executable, errmsg);
+      return -1;
+   }
+
+   if (one_per_job) {
+      debug_printf("Exec failure on %s: %s\n", executable, errmsg);
+      fprintf(stderr, "%s: %s\n", executable, errmsg);
+      return -1;
+   }
+   return -1;
+}
+
 /**
  * Are you staring at this strange code after running TotalView (or another debugger)?
  *
@@ -298,7 +327,7 @@ void test_log(const char *name)
  **/
 int main(int argc, char *argv[])
 {
-   int error, result;
+   int result;
    char **j, *spindle_env;
 
    LOGGING_INIT_PREEXEC("Client");
@@ -315,16 +344,14 @@ int main(int argc, char *argv[])
       if (strcasecmp(spindle_env, "false") == 0 || strcmp(spindle_env, "0") == 0) {
          debug_printf("Turning off spindle from bootstrapper because SPINDLE is %s\n", spindle_env);
          execvp(cmdline[0], cmdline);
-         fprintf(stderr, "%s: Command not found.\n", cmdline[0]);
-         return -1;
+         return handle_exec_failure(cmdline, errno);
       }
    }
 
    if (isCompiler(cmdline[0])) {
       debug_printf("Turning off spindle because we're running a compiler: %s\n", cmdline[0]);
       execvp(cmdline[0], cmdline);
-      fprintf(stderr, "%s: Command not found.\n", cmdline[0]);
-      return -1;
+      return handle_exec_failure(cmdline, errno);
    }
 
    orig_location = parse_location(symbolic_location, number);
@@ -381,12 +408,10 @@ int main(int argc, char *argv[])
     **/
    setup_environment();
    execvp(executable, cmdline);
+   
 
    /**
     * Exec error handling
     **/
-   error = errno;
-   err_printf("Error execing app: %s\n", strerror(error));
-
-   return -1;
+   return handle_exec_failure(cmdline, errno);
 }

--- a/src/client/beboot/spindle_bootstrap.c
+++ b/src/client/beboot/spindle_bootstrap.c
@@ -269,12 +269,6 @@ static void get_clientlib()
    char *default_libstr = (opts & OPT_SUBAUDIT) ? default_subaudit_libstr : default_audit_libstr;
    int errorcode;
    
-   if (!(opts & OPT_RELOCAOUT)) {
-      debug_printf3("Using default client_lib %s\n", default_libstr);
-      client_lib = default_libstr;
-      return;
-   }
-
    get_relocated_file(ldcsid, default_libstr, 1, &client_lib, &errorcode);
    if (client_lib == NULL) {
       client_lib = default_libstr;
@@ -364,12 +358,10 @@ int main(int argc, char *argv[])
       launch_daemon(location);
    }
    
-   if (opts & OPT_RELOCAOUT) {
-      result = establish_connection();
-      if (result == -1) {
-         err_printf("spindle_bootstrap failed to connect to daemons\n");
-         return -1;
-      }
+   result = establish_connection();
+   if (result == -1) {
+      err_printf("spindle_bootstrap failed to connect to daemons\n");
+      return -1;
    }
 
    if ((opts & OPT_SHMCACHE) && cachesize) {

--- a/src/client/client_comlib/client_api.c
+++ b/src/client/client_comlib/client_api.c
@@ -413,6 +413,36 @@ int send_procmaps_query(int fd, int pid, char *result)
    return 0;   
 }
 
+int send_pickone_query(int fd, char *key, int *result)
+{
+   ldcs_message_t message;
+   char buffer[MAX_PATH_LEN+1];
+
+   debug_printf3("Sending pickone query\n");
+
+   strncpy(buffer, key, MAX_PATH_LEN);
+   buffer[MAX_PATH_LEN] = '\0';
+   message.header.type = LDCS_MSG_PICKONE_REQ;
+   message.header.len = key ? strlen(key)+1 : 0;
+   message.data = buffer;
+
+   COMM_LOCK;
+
+   client_send_msg(fd, &message);
+   client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+
+   COMM_UNLOCK;
+
+   if (message.header.type != LDCS_MSG_PICKONE_RESP) {
+      err_printf("Received incorrect response to procmaps query %d\n", message.header.type);
+      assert(0);
+   }
+
+   *result = *((int *) message.data);
+   debug_printf2("Pickone for '%s' returned %d\n", key, *result);
+   return 0;
+}
+
 int send_end(int fd) {
    ldcs_message_t message;
    

--- a/src/client/client_comlib/client_api.h
+++ b/src/client/client_comlib/client_api.h
@@ -40,6 +40,7 @@ int send_ldso_info_request(int fd, const char *ldso_path, char *result_path);
 int send_orig_path_request(int fd, const char *path, char *newpath);
 int send_local_prefix_request(int fd, char **result);
 int send_procmaps_query(int fd, int pid, char *result);
+int send_pickone_query(int fd, char *key, int *result);
 
 int get_python_prefix(int fd, char **prefix);
 

--- a/src/cobo/cobo.c
+++ b/src/cobo/cobo.c
@@ -52,7 +52,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #define COBO_CONNECT_SLEEP   (10) /* milliseconds -- wait this long before trying a new round of connects() */
 #endif
 #ifndef COBO_CONNECT_TIMELIMIT
-#define COBO_CONNECT_TIMELIMIT (600) /* seconds -- wait this long before giving up for good */
+#define COBO_CONNECT_TIMELIMIT (60) /* seconds -- wait this long before giving up for good */
 #endif
 
 #if defined(_IA64_)

--- a/src/flux/flux-spindle.c
+++ b/src/flux/flux-spindle.c
@@ -17,6 +17,33 @@
 
 #include <spindle_launch.h>
 
+#define debug_printf(PRIORITY, FORMAT, ...)                         \
+   do {                                                             \
+      spindle_debug_printf(PRIORITY, FORMAT "\n", ## __VA_ARGS__);  \
+      shell_debug(FORMAT, ## __VA_ARGS__);                          \
+   } while (0)
+
+#define err_printf(PRIORITY, FORMAT, ...)                            \
+   do {                                                              \
+      spindle_debug_printf(PRIORITY, FORMAT "\n", ## __VA_ARGS__);   \
+      shell_die(1, FORMAT, ## __VA_ARGS__);                          \
+   } while (0)
+
+#define errno_printf(PRIORITY, FORMAT, ...)                          \
+   do {                                                              \
+      spindle_debug_printf(PRIORITY, FORMAT "\n", ## __VA_ARGS__);   \
+      shell_die_errno(1, FORMAT, ## __VA_ARGS__);                    \
+   } while (0)
+
+#define logerrno_printf(PRIORITY, FORMAT, ...)                        \
+   do {                                                               \
+      int log_errno_result;                                           \
+      spindle_debug_printf(PRIORITY, FORMAT "\n", ## __VA_ARGS__);    \
+      log_errno_result = shell_log_errno(FORMAT, ## __VA_ARGS__);     \
+      return log_errno_result;                                        \
+   } while (0)
+
+
 struct spindle_ctx {
     spindle_args_t params;   /* Spindle parameters                        */
     int flags;               /* Spindle args initialzation flags          */
@@ -83,6 +110,23 @@ error:
     return NULL;
 }
 
+static int spindle_is_enabled(struct spindle_ctx *ctx)
+{
+   char *spindle_env;
+
+   spindle_env = getenv("SPINDLE");
+   if (spindle_env) {
+      if (strcasecmp(spindle_env, "false") == 0 || strcmp(spindle_env, "0") == 0) {
+         return 0;
+      }
+   }
+
+   if (ctx->params.opts & OPT_OFF) {
+      return 0;
+   }
+
+   return 1;
+}
 
 /*  Create a spindle plugin ctx from jobid 'id', shell rank 'rank',
  *   and an Rv1 json object.
@@ -152,45 +196,55 @@ static int run_spindle_backend (struct spindle_ctx *ctx)
 {
    sigset_t sset;
 
-    ctx->backend_pid = fork ();
-    if (ctx->backend_pid == 0) {
-       enableSpindleForceExitBE();
+   if (!spindle_is_enabled(ctx)) {
+      debug_printf(1, "Spindle disabled. Not starting BE");
+      return 0;
+   }
+   
+   ctx->backend_pid = fork ();
+   if (ctx->backend_pid == 0) {
+      enableSpindleForceExitBE();
 
-       /* Set signal handlers for ctrl-c and related signals. */       
-       signal(SIGINT, onTermSignal);
-       signal(SIGTERM, onTermSignal);
-       signal(SIGALRM, onAlarm);
+      /* Set signal handlers for ctrl-c and related signals. */       
+      signal(SIGINT, onTermSignal);
+      signal(SIGTERM, onTermSignal);
+      signal(SIGALRM, onAlarm);
        
-       sigprocmask(SIG_BLOCK, NULL, &sset);
-       sigdelset(&sset, SIGINT);
-       sigdelset(&sset, SIGTERM);
-       sigdelset(&sset, SIGALRM);
-       sigprocmask(SIG_SETMASK, &sset, NULL);
+      sigprocmask(SIG_BLOCK, NULL, &sset);
+      sigdelset(&sset, SIGINT);
+      sigdelset(&sset, SIGTERM);
+      sigdelset(&sset, SIGALRM);
+      sigprocmask(SIG_SETMASK, &sset, NULL);
 
-        /* N.B.: spindleRunBE() blocks, which is why we run it in a child
-         */
-        if (spindleRunBE (ctx->params.port,
-                          ctx->params.num_ports,
-                          ctx->id,
-                          OPT_SEC_MUNGE,
-                          NULL) < 0) {
-            fprintf (stderr, "spindleRunBE failed!\n");
-            exit (1);
-        }
-        exit (0);
-    }
-    shell_debug ("started spindle backend pid = %u", ctx->backend_pid);
-    return 0;
+      /* N.B.: spindleRunBE() blocks, which is why we run it in a child
+       */
+      if (spindleRunBE (ctx->params.port,
+                        ctx->params.num_ports,
+                        ctx->id,
+                        OPT_SEC_MUNGE,
+                        NULL) < 0) {
+         fprintf (stderr, "spindleRunBE failed!\n");
+         exit (1);
+      }
+      exit (0);
+   }
+   debug_printf(2, "started spindle backend pid = %u", ctx->backend_pid);
+   return 0;
 }
 
 /*  Run spindle frontend. Only in shell rank 0.
  */
 static void run_spindle_frontend (struct spindle_ctx *ctx)
 {
-        /* Blocks untile backends connect */
-        if (spindleInitFE ((const char **) ctx->hosts, &ctx->params) < 0)
-            shell_die (1, "spindleInitFE");
-        shell_debug ("started spindle frontend");
+   if (!spindle_is_enabled(ctx)) {
+      debug_printf(2, "Spindle disabled. Not starting BE");
+      return;
+   }
+
+   /* Blocks untile backends connect */
+   if (spindleInitFE ((const char **) ctx->hosts, &ctx->params) < 0)
+      err_printf(1, "spindleInitFE");
+   debug_printf(2, "started spindle frontend");
 }
 
 /*  Callback for watching the exec eventlog
@@ -210,10 +264,10 @@ static void wait_for_shell_init (flux_future_t *f, void *arg)
     }
 
     if (flux_job_event_watch_get (f, &event) < 0)
-        shell_die_errno (1, "spindle failed waiting for shell.init event");
+        errno_printf(1, "spindle failed waiting for shell.init event");
     if (!(o = json_loads (event, 0, NULL))
             || json_unpack (o, "{s:s}", "name", &name) < 0)
-        shell_die_errno (1, "failed to get event name");
+        errno_printf(1, "failed to get event name");
     if (strcmp (name, "shell.init") == 0) {
         rc = json_unpack (o,
                 "{s:{s:i s:i}}",
@@ -244,7 +298,7 @@ static int parse_yesno(opt_t *opt, opt_t flag, const char *yesno)
    else if (strcasecmp(yesno, "yes") == 0 || strcasecmp(yesno, "true") == 0 || strcasecmp(yesno, "1") == 0)
       *opt |= 1;
    else
-      return shell_log_errno ("Error in spindle option: Expected 'yes' or 'no', got %s", yesno);
+      logerrno_printf(1, "Error in spindle option: Expected 'yes' or 'no', got %s", yesno);
    return 0;
 }
 
@@ -300,7 +354,7 @@ static int sp_getopts (flux_shell_t *shell, struct spindle_ctx *ctx)
                         "numa-files", &numafiles,
                         "preload", &preload,
                         "level", &level) < 0)
-        return shell_log_errno ("Error in spindle option: %s", error.text);
+       logerrno_printf (1, "Error in spindle option: %s", error.text);
 
     if (noclean)
         ctx->params.opts |= OPT_NOCLEAN;
@@ -338,7 +392,7 @@ static int sp_getopts (flux_shell_t *shell, struct spindle_ctx *ctx)
     if (pyprefix) {
         char *tmp;
         if (asprintf (&tmp, "%s:%s", ctx->params.pythonprefix, pyprefix) < 0)
-            return shell_log_errno ("unable to append to pythonprefix");
+           logerrno_printf (1, "unable to append to pythonprefix");
         free (ctx->params.pythonprefix);
         ctx->params.pythonprefix = tmp;
     }
@@ -407,21 +461,22 @@ static int sp_init (flux_plugin_t *p,
     const char *debug;
     const char *tmpdir;
     const char *test;
+    const char *spindle_enabled;
 
     if (!(shell = flux_plugin_get_shell (p))
         || !(h = flux_shell_get_flux (shell)))
-        return shell_log_errno ("failed to get shell or flux handle");
+       logerrno_printf (1, "failed to get shell or flux handle");
 
     if (flux_shell_getopt (shell, "spindle", NULL) != 1)
         return 0;
-
-    shell_debug ("initializing spindle for use with flux");
 
     /*  If SPINDLE_DEBUG is set in the environment of the job, propagate
      *  it into the shell so we get spindle debugging for this session.
      */
     if ((debug = flux_shell_getenv (shell, "SPINDLE_DEBUG")))
         setenv ("SPINDLE_DEBUG", debug, 1);
+
+    debug_printf(1, "initializing spindle for use with flux");
 
     /*  The spindle testsuite requires SPINDLE_TEST
      */
@@ -436,6 +491,10 @@ static int sp_init (flux_plugin_t *p,
         tmpdir = "/tmp";
     setenv ("TMPDIR", tmpdir, 1);
 
+    spindle_enabled = flux_shell_getenv (shell, "SPINDLE");
+    if (spindle_enabled)
+       setenv("SPINDLE", spindle_enabled, 1);
+
     /*  Get the jobid, R, and shell rank
      */
     if (flux_shell_info_unpack (shell,
@@ -443,7 +502,7 @@ static int sp_init (flux_plugin_t *p,
                                 "jobid", &id,
                                 "R", &R,
                                 "rank", &shell_rank) < 0)
-        return shell_log_errno ("Failed to unpack shell info");
+       logerrno_printf (1, "Failed to unpack shell info");
 
     /*  Create an object for spindle related context.
      *
@@ -456,7 +515,7 @@ static int sp_init (flux_plugin_t *p,
                                 ctx,
                                 (flux_free_f) spindle_ctx_destroy) < 0) {
         spindle_ctx_destroy (ctx);
-        return shell_log_errno ("failed to create spindle ctx");
+        logerrno_printf (1, "failed to create spindle ctx");
     }
 
     /*  Fill in the spindle_args_t with defaults from Spindle.
@@ -469,7 +528,7 @@ static int sp_init (flux_plugin_t *p,
                                     0,
                                     NULL,
                                     NULL) < 0)
-        return shell_log_errno ("fillInSpindleArgsCmdlineFE failed");
+       logerrno_printf (1, "fillInSpindleArgsCmdlineFE failed");
 
 
     /*  Read other spindle options from spindle option in jobspec:
@@ -477,6 +536,10 @@ static int sp_init (flux_plugin_t *p,
     if (sp_getopts (shell, ctx) < 0)
         return -1;
     if (ctx->params.opts & OPT_OFF) {
+       return 0;
+    }
+
+    if (!spindle_is_enabled(ctx)) {
        return 0;
     }
     
@@ -525,8 +588,9 @@ static int sp_task (flux_plugin_t *p,
                     flux_plugin_arg_t *arg,
                     void *data)
 {
+    debug_printf(1, "In flux plugin sp_task");   
     struct spindle_ctx *ctx = flux_plugin_aux_get (p, "spindle");
-    if (ctx && ctx->argc > 0 && !(ctx->params.opts & OPT_OFF)) {
+    if (ctx && ctx->argc > 0 && spindle_is_enabled(ctx)) {
         int i;
         flux_shell_t *shell = flux_plugin_get_shell (p);
         flux_shell_task_t *task = flux_shell_current_task (shell);
@@ -551,7 +615,10 @@ static int sp_exit (flux_plugin_t *p,
                     flux_plugin_arg_t *arg,
                     void *data)
 {
+    debug_printf(1, "In flux plugin sp_exit");
     struct spindle_ctx *ctx = flux_plugin_aux_get (p, "spindle");
+    if (!spindle_is_enabled(ctx))
+       return 0;
     if (ctx && ctx->params.opts & OPT_OFF)
        return 0;    
     if (ctx && ctx->shell_rank == 0)

--- a/src/include/ldcs_api.h
+++ b/src/include/ldcs_api.h
@@ -80,6 +80,8 @@ typedef enum {
    LDCS_MSG_ALIAS,
    LDCS_MSG_PROCMAPS_REQ,
    LDCS_MSG_PROCMAPS_RESP,
+   LDCS_MSG_PICKONE_REQ,
+   LDCS_MSG_PICKONE_RESP,   
    LDCS_MSG_UNKNOWN
 } ldcs_message_ids_t;
 

--- a/src/server/auditserver/cleanup_proc.cc
+++ b/src/server/auditserver/cleanup_proc.cc
@@ -52,8 +52,8 @@ static bool longest_str_first(const string &a, const string &b)
 
 static void rmDirSet(const set<string> &dirs, const char *prefix_dir)
 {
-   string path_sep("/");
-   size_t prefix_size = strlen(prefix_dir);
+   string path_sep("/");   
+   size_t prefix_size = prefix_dir ? strlen(prefix_dir) : 0;
    
    for (set<string>::const_iterator i = dirs.begin(); i != dirs.end(); i++) {
       DIR *dir = opendir(i->c_str());

--- a/src/server/auditserver/ldcs_audit_server_handlers.c
+++ b/src/server/auditserver/ldcs_audit_server_handlers.c
@@ -162,6 +162,7 @@ static int handle_client_metadata(ldcs_process_data_t *procdata, int nc);
 static int handle_client_metadata_result(ldcs_process_data_t *procdata, int nc, metadata_t mdtype);
 static int handle_client_metadata_self(ldcs_process_data_t *procdata, int nc);
 static int handle_client_procmaps_msg(ldcs_process_data_t *procdata, int nc, ldcs_message_t *msg);
+static int handle_client_pickone_msg(ldcs_process_data_t *procdata, int nc, ldcs_message_t *msg);
 static int handle_metadata_request(ldcs_process_data_t *procdata, char *pathname, metadata_t mdtype, node_peer_t from);
 static int handle_metadata_request_recv(ldcs_process_data_t *procdata, ldcs_message_t *msg, metadata_t mdtype, node_peer_t peer);
 static int handle_load_and_broadcast_metadata(ldcs_process_data_t *procdata, char *pathname, metadata_t mdtype);
@@ -176,6 +177,7 @@ static int handle_msgbundle(ldcs_process_data_t *procdata, node_peer_t peer, ldc
 static int handle_setup_alias(ldcs_process_data_t *procdata, char *pathname, char *alias_to);
 static int handle_client_localprefix_req(ldcs_process_data_t *procdata, int nc);
 static int handle_close_client_query(ldcs_process_data_t *procdata, int nc);
+
 /**
  * Query from client to server.  Returns info about client's rank in server data structures. 
  **/
@@ -1859,6 +1861,8 @@ int handle_client_message(ldcs_process_data_t *procdata, int nc, ldcs_message_t 
          return handle_client_origpath_msg(procdata, nc, msg);
       case LDCS_MSG_PROCMAPS_REQ:
          return handle_client_procmaps_msg(procdata, nc, msg);
+      case LDCS_MSG_PICKONE_REQ:
+         return handle_client_pickone_msg(procdata, nc, msg);
       case LDCS_MSG_END:
          return handle_client_end(procdata, nc);
       default:
@@ -2857,6 +2861,56 @@ static int handle_client_procmaps_msg(ldcs_process_data_t *procdata, int nc, ldc
    
    return 0;
    
+}
+
+static int handle_client_pickone_resp(ldcs_process_data_t *procdata, int nc, int you)
+{
+   int result;
+   ldcs_message_t outmsg;
+   ldcs_client_t *client;
+   client = procdata->client_table + nc;
+
+   outmsg.header.type = LDCS_MSG_PICKONE_RESP;
+   outmsg.header.len = sizeof(int);
+   outmsg.data = (void *) &you;
+
+   result = ldcs_send_msg(client->connid, &outmsg);
+   procdata->server_stat.clientmsg.cnt++;
+   procdata->server_stat.clientmsg.time += (ldcs_get_time() - client->query_arrival_time);
+   handle_close_client_query(procdata, nc);
+   
+   return result;
+}
+
+static int handle_client_pickone_msg(ldcs_process_data_t *procdata, int nc, ldcs_message_t *msg)
+{
+   char key[MAX_PATH_LEN+1];
+   int already_exists;
+   
+   assert(nc != -1);
+
+   assert(msg->header.len <= sizeof(key));
+   if (msg->header.len)
+      memcpy(key, msg->data, msg->header.len);
+   else
+      strncpy(key, "[NULL]", sizeof(key));
+   key[MAX_PATH_LEN] = '\0';
+
+   already_exists = ldcs_cache_pickone_get(key);
+   if (already_exists) {
+      debug_printf2("Responding to pickone of key %s with 'not you' because this node already responded\n", key);
+      return handle_client_pickone_resp(procdata, nc, 0);
+   }
+   ldcs_cache_pickone_set(key);
+
+   if (ldcs_audit_server_md_is_responsible(procdata, key)) {
+      debug_printf2("Responding to pickone of key %s with 'you'\n", key);
+      return handle_client_pickone_resp(procdata, nc, 1);
+   }
+   else {
+      debug_printf2("Responding to pickone of key %s with 'not you' because this node is not reponsible\n", key);
+      return handle_client_pickone_resp(procdata, nc, 0);
+   }
 }
 
 /**

--- a/src/server/cache/ldcs_cache.cc
+++ b/src/server/cache/ldcs_cache.cc
@@ -22,6 +22,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include <string>
 #include <unordered_map>
+#include <set>
 #include <utility>
 #include <list>
 #include <cassert>
@@ -487,4 +488,21 @@ char *ldcs_cache_result_to_str(ldcs_cache_result_t res)
       default: result = "INVALID STATE"; break;
    }
    return const_cast<char *>(result);
+}
+
+static set<string> pickone_cache;
+
+int ldcs_cache_pickone_get(char *key)
+{
+   string key_s(key);
+   if (pickone_cache.find(key_s) != pickone_cache.end())
+      return 1;
+   else
+      return 0;
+}
+
+void ldcs_cache_pickone_set(char *key)
+{
+   string key_s(key);
+   pickone_cache.insert(key_s);
 }

--- a/src/server/cache/ldcs_cache.h
+++ b/src/server/cache/ldcs_cache.h
@@ -71,7 +71,8 @@ int ldcs_cache_get_buffer(char *dirname, char *filename, ldcs_hash_fileobj_t obj
 char *ldcs_cache_result_to_str(ldcs_cache_result_t res);
 void ldcs_cache_addFileDir(char *dname, char *fname);
 
-
+int ldcs_cache_pickone_get(char *key);
+void ldcs_cache_pickone_set(char *key);
 
 #if defined(__cplusplus)
 }

--- a/src/server/comlib/ldcs_api_util.c
+++ b/src/server/comlib/ldcs_api_util.c
@@ -86,7 +86,9 @@ char* _message_type_to_str (ldcs_message_ids_t type) {
       STR_CASE(LDCS_MSG_BUNDLE);
       STR_CASE(LDCS_MSG_ALIAS);
       STR_CASE(LDCS_MSG_PROCMAPS_REQ);
-      STR_CASE(LDCS_MSG_PROCMAPS_RESP);      
+      STR_CASE(LDCS_MSG_PROCMAPS_RESP);
+      STR_CASE(LDCS_MSG_PICKONE_REQ);
+      STR_CASE(LDCS_MSG_PICKONE_RESP);
       STR_CASE(LDCS_MSG_UNKNOWN);
    }
    return "unknown";


### PR DESCRIPTION
Main fixes:
- Add capability for letting clients select one designated client out of the set of all clients
- Use above capability for printing error messages on exec error from spindle bootstrapping
- Fix fault during cleanup on certain early spindle error terminations.

While developing and debugging the above, several other fixes:
- Relocate spindle audit library always when spindle is enabled. Was previously only relocated when executables were relocated.
- Improve debug printing in flux plugin.
- Reduce timeout for server connection errors from 5 minutes to 1 minute.