### PR TITLE
Fix config error when turning on shmcache

### DIFF
--- a/src/fe/startup/config_mgr.cc
+++ b/src/fe/startup/config_mgr.cc
@@ -837,6 +837,7 @@ bool ConfigMap::toSpindleArgs(spindle_args_t &args, bool alloc_strs) const
             break;
          case confShmcacheSize:
             args.shm_cache_size = (unsigned int) numresult;
+            setopt(args.opts, OPT_SHMCACHE, (numresult != 0));
             break;
          case confDebug:
             setopt(args.opts, OPT_DEBUG, boolresult);


### PR DESCRIPTION
Fix error that occurred with new config system where setting shmcache size was not turning on the cache. 