### PR TITLE
flux: set TMPDIR in job environment if not set

### DIFF
--- a/src/flux/flux-spindle.c
+++ b/src/flux/flux-spindle.c
@@ -550,8 +550,11 @@ static int sp_init (flux_plugin_t *p,
      *  environment, or use /tmp if TMPDIR not set.
      */
     tmpdir = flux_shell_getenv (shell, "TMPDIR");
-    if (!tmpdir)
+    if (!tmpdir) {
         tmpdir = "/tmp";
+        if (flux_shell_setenv (shell, 1, "TMPDIR", "%s", tmpdir) < 0)
+            logerrno_printf (1, "failed to set TMPDIR=/tmp in job environment");
+    }
     setenv ("TMPDIR", tmpdir, 1);
 
     spindle_enabled = flux_shell_getenv (shell, "SPINDLE");


### PR DESCRIPTION
Problem: If TMIDIR is not set in the Flux job environment, Spindle fails.

The flux plugin already checks for TMPDIR and falls back to /tmp if missing, but it only sets TMPDIR in the job shell environment in this case.

Also set it in the job environment when TMPDIR is not set.