### PR TITLE
Retain original realpath semantics by zero'ing errno on success

### DIFF
--- a/src/client/client/realpath.c
+++ b/src/client/client/realpath.c
@@ -501,6 +501,9 @@ char *spindle_realpath (const char *name, char *resolved)
    scratch_buffer_free (&bufs.link);
    scratch_buffer_free (&bufs.extra);
    scratch_buffer_free (&bufs.rname);
+   debug_printf3("spindle_realpath(%s, %p) returning %s\n", name, resolved, result);
+   if (result)
+      set_errno(0);
    return result;
 }
 


### PR DESCRIPTION
Fix an issue with new realpath implementation where errno was getting set even on a successful realpath. POSIX doesn't require this, but we want to match the behavior of original realpath.