### PR TITLE
Fixes runTests failure when specifying location.

### DIFF
--- a/src/logging/spindle_logd.cc
+++ b/src/logging/spindle_logd.cc
@@ -201,7 +201,7 @@ private:
    std::vector<std::string> err_strings;
    std::set<std::pair<int, std::string> > target_libs;
    std::set<std::pair<int, std::string> > libs_loaded;
-   std::string tmp_dir;
+   char *location;
 
    void logerror(std::string s)
    {
@@ -248,7 +248,7 @@ public:
          tmp_s = getenv("TEMPDIR");
       if (!tmp_s)
          tmp_s = "/tmp";
-      tmp_dir = tmp_s;
+      location = strdup(tmp_s);
    }
 
    ~TestVerifier()
@@ -267,7 +267,7 @@ public:
           strstr(filename, "retzero") == NULL &&
           strstr(filename, ".py") == NULL)
          return true;
-      bool is_from_temp = (strstr(filename, tmp_dir.c_str()) != NULL) && (strncmp(filename, "/__not_exist", 12) != 0);
+      bool is_from_temp = (strstr(filename, location) != NULL) && (strncmp(filename, "/__not_exist", 12) != 0);
       bool is_local_test = strstr(filename, "liblocal") != NULL;
 
       if (is_from_temp && !is_local_test && ret_code == -1) {
@@ -293,6 +293,13 @@ public:
       char buffer[4096];
       int ret;
 
+      if (strstr(s, "<internal> location=" ) == s ){
+        free( location );
+        const char *loc_start = strstr( s, "=") + 1;
+        size_t loc_len = strlen( loc_start );
+        location = strdup( loc_start );
+        location[ loc_len - 1 ] = '\0'; // Remove trailing '\n'.
+      }
       if (strstr(s, "open(") == s) {
          const char *first_quote, *last_quote, *equals;
          int len;

--- a/src/server/startup/spindle_be.cc
+++ b/src/server/startup/spindle_be.cc
@@ -152,6 +152,7 @@ int spindleRunBE(unsigned int port, unsigned int num_ports, unique_id_t unique_i
    debug_printf("Translated location from %s to %s\n", args.location, new_location);
    free(args.location);
    args.location = new_location;
+   test_printf("<internal> location=%s\n", args.location);
 
    result = ldcs_audit_server_process(&args);
    if (result == -1) {


### PR DESCRIPTION
The TestVerifier constructor checks for $TMPDIR, $TEMPDIR, and "/tmp" in turn to determine the cache directory to be used.

In the rest of Spindle, that choice can be overridden by the "location" parameter.  That parameter has not historically been communicated through to the testing subsystem, leading to spurious failures due to directory name mismatches.

Fixed by having the backend code send a "magic" message to the testing subsystem with the correct location.  This solution works because backend initialization is guaranteed to complete before the application could send its first test messages.