### PR TITLE
Several fixes around application compatibility and Python

### DIFF
--- a/src/client/auditclient/auditclient_x86_64.c
+++ b/src/client/auditclient/auditclient_x86_64.c
@@ -102,8 +102,9 @@ static int bind_global_relocations(struct link_map *map, Elf64_Rela *relocs, Elf
          *got_entry = target;
          if (!made_reloc_table_writable) {
             reloc_table_pagebase = ((Elf64_Addr) relocs) & ~((Elf64_Addr) (getpagesize()-1));
-            reloc_table_size = ((num_relocs + 1) * sizeof(Elf64_Rela)) - 1;
-            result = mprotect((void *) reloc_table_pagebase, reloc_table_size, PROT_READ | PROT_WRITE);
+            reloc_table_size = ((num_relocs + 1) * sizeof(Elf64_Rela)) - 1 + (((Elf64_Addr) relocs) - reloc_table_pagebase);
+            debug_printf3("mprotect(%p, %lu, PROT_READ|PROT_WRITE|PROT_EXEC) making GOT table writiable\n", (void *) reloc_table_pagebase, reloc_table_size);
+            result = mprotect((void *) reloc_table_pagebase, reloc_table_size, PROT_READ | PROT_WRITE | PROT_EXEC);
             if (result == -1) {
                error = errno;
                err_printf("Could not mprotect for write to relocs 0x%lx +%lu: %s\n",
@@ -118,16 +119,6 @@ static int bind_global_relocations(struct link_map *map, Elf64_Rela *relocs, Elf
       }
    }
 
-   if (made_reloc_table_writable) {
-      result = mprotect((void *) reloc_table_pagebase, reloc_table_size, PROT_READ);
-      if (result == -1) {
-         error = errno;
-         err_printf("Could not mprotect restore reloctable 0x%lx +%lu: %s\n",
-                    reloc_table_pagebase, reloc_table_size, strerror(error));
-         return -1;
-      }
-   }
-         
    return 0;
 }
 

--- a/src/client/auditclient/writablegot.c
+++ b/src/client/auditclient/writablegot.c
@@ -210,6 +210,7 @@ static int markw(struct got_range_t *got)
    pagesize = (unsigned long) getpagesize();
    pagestart = got->start & ~(pagesize-1);
 
+   debug_printf3("Setting permissions on %p +%lx to %d\n", (void *) pagestart, got->end - pagestart, (PROT_READ | PROT_WRITE));
    result = mprotect((void*) pagestart, got->end - pagestart, PROT_READ | PROT_WRITE);
    if (result == -1) {
       err_printf("Could not mark GOT region %lx to %lx as writable\n", pagestart, got->end);

--- a/src/client/client/intercept_exec.c
+++ b/src/client/client/intercept_exec.c
@@ -251,8 +251,16 @@ static int prep_exec(const char *filepath, char **argv,
 {
    int result;
    char *interp_name;
+   int i;
 
    debug_printf3("prep_exec for filepath %s to newpath %s\n", filepath, newpath);
+   if (spindle_debug_prints >= 3) {
+      debug_printf3("Args for exec are:\n");
+      for (i = 0; argv[i]; i++) {
+         debug_printf3("%d. %s\n", i, argv[i]);
+      }
+   }
+   
    
    if (errcode == EACCES) {
       strncpy(newpath, filepath, newpath_size);

--- a/src/logging/spindle_logd.cc
+++ b/src/logging/spindle_logd.cc
@@ -377,7 +377,7 @@ public:
 class MsgReader
 {
 private:
-   static const unsigned int MAX_MESSAGE = 4096;
+   static const unsigned int MAX_MESSAGE = 16536;
    static const unsigned int LISTEN_BACKLOG = 64;
 
    struct Connection {

--- a/src/server/auditserver/ldcs_audit_server_filemngt.c
+++ b/src/server/auditserver/ldcs_audit_server_filemngt.c
@@ -192,7 +192,7 @@ int filemngt_encode_packet(char *filename, void *filecontents, size_t filesize, 
 {
    int cur_pos = 0;
    int filename_len = strlen(filename) + 1;
-   int is_elf = filemngt_is_elf_file(filecontents, *buffer_size);
+   int is_elf = filemngt_is_elf_file(filecontents, filesize);
    //TODO: Remove filesize from allocation if we're doing a non-contig send. Wastes memory.
    *buffer_size = sizeof(is_elf) + sizeof(stripped) + filename_len + sizeof(filename_len) + sizeof(filesize) + filesize;
    *buffer = (char *) malloc(*buffer_size);

--- a/src/server/auditserver/ldcs_audit_server_filemngt.c
+++ b/src/server/auditserver/ldcs_audit_server_filemngt.c
@@ -97,9 +97,9 @@ char *filemngt_calc_localname(char *global_name, calc_local_t reqtype)
    //The naming decisions here need to be cordinated with name parsing in
    // cache/global_name.c
    static unsigned int unique_str_num = 0;
-   char target[MAX_NAME_LEN+1];
-   char dirpart[MAX_NAME_LEN+1];
-   char filepart[MAX_FILENAME_LEN+1];
+   char target[MAX_PATH_LEN+1];
+   char dirpart[MAX_PATH_LEN+1];
+   char filepart[MAX_PATH_LEN+1];
    char *endslash, *lastslash;
    const char *prefix = NULL;
    size_t dirpart_size, filepart_size;

--- a/src/server/cache/global_name.c
+++ b/src/server/cache/global_name.c
@@ -149,6 +149,7 @@ void add_global_name(char* pathname, char* localpath)
   char *dname, *fname;
   int index;
 
+  debug_printf3("add_global_name is parsing %s\n", localpath);
   parse_name(localpath, &dname, &fname, &index);
   if (index == -1) {
      err_printf("Given name %s that couldn't be parsed\n", localpath);


### PR DESCRIPTION
- Fix uninitialized memory access error found with valgrind
- Fix path truncation when calculating local names. 
- The logging daemon could crash when given 4096+ long line lengths. Moved value to 16k for now, but need to go back and make it support arbitrary line lengths.
- Fixed crashes on libraries that had no PLT entries from that stemmed from spindle changing reloc table permissions. 