### PR TITLE
Add configure argument --with-default-local-prefix

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -127,6 +127,10 @@
 /* The default local directory for Spindle */
 #undef SPINDLE_LOC
 
+/* The default colon-separated list of directories that Spindle will not cache
+   files out of */
+#undef SPINDLE_LOCAL_PREFIX
+
 /* The maximum port value */
 #undef SPINDLE_MAX_PORT
 

--- a/configure
+++ b/configure
@@ -847,6 +847,7 @@ enable_maintainer_mode
 with_default_port
 with_default_num_ports
 with_localstorage
+with_default_local_prefix
 with_testrm
 with_rm
 enable_slurm
@@ -1589,6 +1590,9 @@ Optional Packages:
                           Number of TCP/IP ports to scan for Spindle server
                           communication
   --with-localstorage=DIR Directory on back-ends for storing relocated files
+  --with-default-local-prefix=DIRS
+                          Colon-seperated list of directories that Spindle
+                          will not cache files out of
   --with-testrm=ARG
   --with-rm=ARG           Default resource manager (valid options are 'slurm',
                           'slurm-plugin', 'flux', and 'serial')
@@ -16565,6 +16569,7 @@ SPINDLE_SOURCE_ROOT=`realpath ${srcdir}`
 DEFAULT_PORT=21940
 DEFAULT_LOC='$TMPDIR'
 DEFAULT_NUM_COBO_PORTS=250
+DEFAULT_LOCAL_PREFIX='/var/:/tmp/:/proc/:/dev/:/sys/'
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable maintainer-specific portions of Makefiles" >&5
@@ -16618,6 +16623,14 @@ else
 fi
 
 
+# Check whether --with-default-local-prefix was given.
+if test "${with_default_local_prefix+set}" = set; then :
+  withval=$with_default_local_prefix; SPINDLE_LOCAL_PREFIX=${withval}
+else
+  SPINDLE_LOCAL_PREFIX="$DEFAULT_LOCAL_PREFIX:$SPINDLE_LOC"
+fi
+
+
 cat >>confdefs.h <<_ACEOF
 #define SPINDLE_PORT $SPINDLE_PORT
 _ACEOF
@@ -16635,6 +16648,11 @@ _ACEOF
 
 cat >>confdefs.h <<_ACEOF
 #define SPINDLE_LOC "$SPINDLE_LOC"
+_ACEOF
+
+
+cat >>confdefs.h <<_ACEOF
+#define SPINDLE_LOCAL_PREFIX "$SPINDLE_LOCAL_PREFIX"
 _ACEOF
 
 

--- a/configure.common.ac
+++ b/configure.common.ac
@@ -3,6 +3,7 @@
 DEFAULT_PORT=21940
 DEFAULT_LOC='$TMPDIR'
 DEFAULT_NUM_COBO_PORTS=250
+DEFAULT_LOCAL_PREFIX='/var/:/tmp/:/proc/:/dev/:/sys/'
 
 AM_MAINTAINER_MODE([disable])
 
@@ -20,10 +21,15 @@ AC_ARG_WITH(localstorage,
             [AS_HELP_STRING([--with-localstorage=DIR],[Directory on back-ends for storing relocated files])],
             [SPINDLE_LOC=${withval}],
             [SPINDLE_LOC=$DEFAULT_LOC])
+AC_ARG_WITH(default-local-prefix,
+            [AS_HELP_STRING([--with-default-local-prefix=DIRS],[Colon-seperated list of directories that Spindle will not cache files out of])],
+            [SPINDLE_LOCAL_PREFIX=${withval}],
+            [SPINDLE_LOCAL_PREFIX="$DEFAULT_LOCAL_PREFIX:$SPINDLE_LOC"])
 AC_DEFINE_UNQUOTED([SPINDLE_PORT],[$SPINDLE_PORT],[The default port for Spindle])
 AC_DEFINE_UNQUOTED([NUM_COBO_PORTS],[$NUM_COBO_PORTS],[Number of ports for COBO to search for an open port])
 AC_DEFINE_UNQUOTED([SPINDLE_MAX_PORT],[$(($SPINDLE_PORT + $NUM_COBO_PORTS - 1))],[The maximum port value])
 AC_DEFINE_UNQUOTED([SPINDLE_LOC],"[$SPINDLE_LOC]",[The default local directory for Spindle])
+AC_DEFINE_UNQUOTED([SPINDLE_LOCAL_PREFIX],"[$SPINDLE_LOCAL_PREFIX]",[The default colon-separated list of directories that Spindle will not cache files out of])
 
 TESTRM=unknown
 AC_ARG_WITH(testrm,

--- a/src/client/config.h.in
+++ b/src/client/config.h.in
@@ -118,6 +118,10 @@
 /* The default local directory for Spindle */
 #undef SPINDLE_LOC
 
+/* The default colon-separated list of directories that Spindle will not cache
+   files out of */
+#undef SPINDLE_LOCAL_PREFIX
+
 /* The maximum port value */
 #undef SPINDLE_MAX_PORT
 

--- a/src/client/configure
+++ b/src/client/configure
@@ -811,6 +811,7 @@ enable_maintainer_mode
 with_default_port
 with_default_num_ports
 with_localstorage
+with_default_local_prefix
 with_testrm
 with_rm
 enable_slurm
@@ -1532,6 +1533,9 @@ Optional Packages:
                           Number of TCP/IP ports to scan for Spindle server
                           communication
   --with-localstorage=DIR Directory on back-ends for storing relocated files
+  --with-default-local-prefix=DIRS
+                          Colon-seperated list of directories that Spindle
+                          will not cache files out of
   --with-testrm=ARG
   --with-rm=ARG           Default resource manager (valid options are 'slurm',
                           'slurm-plugin', 'flux', and 'serial')
@@ -12537,6 +12541,7 @@ SPINDLE_SOURCE_ROOT=`realpath ${srcdir}/../..`
 DEFAULT_PORT=21940
 DEFAULT_LOC='$TMPDIR'
 DEFAULT_NUM_COBO_PORTS=250
+DEFAULT_LOCAL_PREFIX='/var/:/tmp/:/proc/:/dev/:/sys/'
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable maintainer-specific portions of Makefiles" >&5
@@ -12590,6 +12595,14 @@ else
 fi
 
 
+# Check whether --with-default-local-prefix was given.
+if test "${with_default_local_prefix+set}" = set; then :
+  withval=$with_default_local_prefix; SPINDLE_LOCAL_PREFIX=${withval}
+else
+  SPINDLE_LOCAL_PREFIX="$DEFAULT_LOCAL_PREFIX:$SPINDLE_LOC"
+fi
+
+
 cat >>confdefs.h <<_ACEOF
 #define SPINDLE_PORT $SPINDLE_PORT
 _ACEOF
@@ -12607,6 +12620,11 @@ _ACEOF
 
 cat >>confdefs.h <<_ACEOF
 #define SPINDLE_LOC "$SPINDLE_LOC"
+_ACEOF
+
+
+cat >>confdefs.h <<_ACEOF
+#define SPINDLE_LOCAL_PREFIX "$SPINDLE_LOCAL_PREFIX"
 _ACEOF
 
 

--- a/src/fe/config.h.in
+++ b/src/fe/config.h.in
@@ -163,6 +163,10 @@
 /* The default local directory for Spindle */
 #undef SPINDLE_LOC
 
+/* The default colon-separated list of directories that Spindle will not cache
+   files out of */
+#undef SPINDLE_LOCAL_PREFIX
+
 /* The maximum port value */
 #undef SPINDLE_MAX_PORT
 

--- a/src/fe/configure
+++ b/src/fe/configure
@@ -832,6 +832,7 @@ enable_maintainer_mode
 with_default_port
 with_default_num_ports
 with_localstorage
+with_default_local_prefix
 with_testrm
 with_rm
 enable_slurm
@@ -1570,6 +1571,9 @@ Optional Packages:
                           Number of TCP/IP ports to scan for Spindle server
                           communication
   --with-localstorage=DIR Directory on back-ends for storing relocated files
+  --with-default-local-prefix=DIRS
+                          Colon-seperated list of directories that Spindle
+                          will not cache files out of
   --with-testrm=ARG
   --with-rm=ARG           Default resource manager (valid options are 'slurm',
                           'slurm-plugin', 'flux', and 'serial')
@@ -16387,6 +16391,7 @@ SPINDLE_SOURCE_ROOT=`realpath ${srcdir}/../..`
 DEFAULT_PORT=21940
 DEFAULT_LOC='$TMPDIR'
 DEFAULT_NUM_COBO_PORTS=250
+DEFAULT_LOCAL_PREFIX='/var/:/tmp/:/proc/:/dev/:/sys/'
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable maintainer-specific portions of Makefiles" >&5
@@ -16440,6 +16445,14 @@ else
 fi
 
 
+# Check whether --with-default-local-prefix was given.
+if test "${with_default_local_prefix+set}" = set; then :
+  withval=$with_default_local_prefix; SPINDLE_LOCAL_PREFIX=${withval}
+else
+  SPINDLE_LOCAL_PREFIX="$DEFAULT_LOCAL_PREFIX:$SPINDLE_LOC"
+fi
+
+
 cat >>confdefs.h <<_ACEOF
 #define SPINDLE_PORT $SPINDLE_PORT
 _ACEOF
@@ -16457,6 +16470,11 @@ _ACEOF
 
 cat >>confdefs.h <<_ACEOF
 #define SPINDLE_LOC "$SPINDLE_LOC"
+_ACEOF
+
+
+cat >>confdefs.h <<_ACEOF
+#define SPINDLE_LOCAL_PREFIX "$SPINDLE_LOCAL_PREFIX"
 _ACEOF
 
 

--- a/src/fe/startup/config_mgr.cc
+++ b/src/fe/startup/config_mgr.cc
@@ -56,6 +56,12 @@ using namespace std;
 #define SPINDLE_LOC_STR "$TMPDIR"
 #endif
 
+#if defined(SPINDLE_LOCAL_PREFIX)
+#define SPINDLE_LOCAL_PREFIX_STR SPINDLE_LOCAL_PREFIX
+#else
+#define SPINDLE_LOCAL_PREFIX_STR "/var/:/tmp/:/proc/:/dev/:/sys/"
+#endif
+
 #if defined(TESTRM)
 #  define DEFAULT_LAUNCHER_STR TESTRM
 #else
@@ -251,7 +257,7 @@ void initOptionsList()
      "Alias for python-prefix" },
    { confExecExcludes, "exec-excludes", shortExecExcludes, groupMisc, cvList, {}, DEFAULT_EXEC_EXCLUDE_LIST,
      "Colon-seperated list of executable names that should not be run under spindle." },
-   { confLocalPrefix, "local-prefix", shortLocalPrefix, groupMisc, cvList, {}, SPINDLE_LOC_STR,
+   { confLocalPrefix, "local-prefix", shortLocalPrefix, groupMisc, cvList, {}, SPINDLE_LOCAL_PREFIX_STR,
      "Colon-seperated list of directories that spindle will not cache files out of" },
    { confDebug, "debug", shortDebug, groupMisc, cvBool, {}, "false",
      "If yes, hide spindle from debuggers so they think libraries come from the original locations.  May cause extra overhead." },

--- a/src/server/config.h.in
+++ b/src/server/config.h.in
@@ -145,6 +145,10 @@
 /* The default local directory for Spindle */
 #undef SPINDLE_LOC
 
+/* The default colon-separated list of directories that Spindle will not cache
+   files out of */
+#undef SPINDLE_LOCAL_PREFIX
+
 /* The maximum port value */
 #undef SPINDLE_MAX_PORT
 

--- a/src/server/configure
+++ b/src/server/configure
@@ -838,6 +838,7 @@ enable_maintainer_mode
 with_default_port
 with_default_num_ports
 with_localstorage
+with_default_local_prefix
 with_testrm
 with_rm
 enable_slurm
@@ -1567,6 +1568,9 @@ Optional Packages:
                           Number of TCP/IP ports to scan for Spindle server
                           communication
   --with-localstorage=DIR Directory on back-ends for storing relocated files
+  --with-default-local-prefix=DIRS
+                          Colon-seperated list of directories that Spindle
+                          will not cache files out of
   --with-testrm=ARG
   --with-rm=ARG           Default resource manager (valid options are 'slurm',
                           'slurm-plugin', 'flux', and 'serial')
@@ -16384,6 +16388,7 @@ SPINDLE_SOURCE_ROOT=`realpath ${srcdir}/../..`
 DEFAULT_PORT=21940
 DEFAULT_LOC='$TMPDIR'
 DEFAULT_NUM_COBO_PORTS=250
+DEFAULT_LOCAL_PREFIX='/var/:/tmp/:/proc/:/dev/:/sys/'
 
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether to enable maintainer-specific portions of Makefiles" >&5
@@ -16437,6 +16442,14 @@ else
 fi
 
 
+# Check whether --with-default-local-prefix was given.
+if test "${with_default_local_prefix+set}" = set; then :
+  withval=$with_default_local_prefix; SPINDLE_LOCAL_PREFIX=${withval}
+else
+  SPINDLE_LOCAL_PREFIX="$DEFAULT_LOCAL_PREFIX:$SPINDLE_LOC"
+fi
+
+
 cat >>confdefs.h <<_ACEOF
 #define SPINDLE_PORT $SPINDLE_PORT
 _ACEOF
@@ -16454,6 +16467,11 @@ _ACEOF
 
 cat >>confdefs.h <<_ACEOF
 #define SPINDLE_LOC "$SPINDLE_LOC"
+_ACEOF
+
+
+cat >>confdefs.h <<_ACEOF
+#define SPINDLE_LOCAL_PREFIX "$SPINDLE_LOCAL_PREFIX"
 _ACEOF
 
 


### PR DESCRIPTION
Previously, the value of `configure --with-localstorage=DIR` was used as the default for both the `--location=val` and the `--local-prefix=val:val:...` arguments to `spindle`. However, there are paths that should be placed in local-prefix by default regardless of where the back-end storage directory is located. 

This pull request adds a new configure option `--with-default-local-prefix=DIRS` which sets the default value of `--local-prefix`. If not specified, `configure` will set the default to `/var/:/tmp/:/proc/:/dev/:/sys/:$SPINDLE_LOC` where `$SPINDLE_LOC` (the value of `--with-localstorage`) is substituted into the string, so that we add the new default paths while maintaining the existing behavior of including the localstorage path in the local prefixes.