### PR TITLE
Fix warnings

### DIFF
--- a/src/biter/biterd.c
+++ b/src/biter/biterd.c
@@ -44,8 +44,8 @@ typedef struct biterd_session {
    int s2c_fd;
    char *c2s_path;
    char *s2c_path;
-   int num_clients;
-   int clients_accepted;
+   uint32_t num_clients;
+   uint32_t clients_accepted;
    void *proc_messages;
    msg_header_t polled_data;
    int has_polled_data;
@@ -55,7 +55,7 @@ typedef struct biterd_session {
 } biterd_session_t;
 
 static biterd_session_t sessions[BITER_MAX_SESSIONS];
-static int max_session = 0;
+static uint32_t max_session = 0;
 
 extern void init_queue(int num_procs, void *session);
 
@@ -117,7 +117,7 @@ int biterd_newsession(const char *tmpdir, int cn_id)
    char *c2s_path = NULL, *s2c_path = NULL;
    int result, c2s_fd = -1, s2c_fd = -1;
    int path_len = strlen(tmpdir) + 32;
-   int session_id, i, unique_number, num_clients;
+   uint32_t session_id, i, unique_number, num_clients;
 
    assert(sizeof(int) == sizeof(uint32_t)); //Fix FD_* macros if this fails on new platform
 
@@ -393,7 +393,7 @@ int biterd_has_data_avail(int session_id, fd_set *readset)
    int client_id;
    int fd = sessions[session_id].c2s_fd;
    int aux_fd = get_aux_fd();
-   int i, orig;
+   uint32_t i, orig;
 
    session = sessions + session_id;
 
@@ -422,8 +422,8 @@ int biterd_has_data_avail(int session_id, fd_set *readset)
 
 int biterd_get_session_proc_w_aux_data(int *session_result, int *proc_result)
 {
-   static int last_session = 0;
-   int cur_session, start_session, j;
+   static uint32_t last_session = 0;
+   uint32_t cur_session, start_session, j;
    biterd_session_t *session;
    cur_session = start_session = last_session;
 

--- a/src/biter/client_queue.c
+++ b/src/biter/client_queue.c
@@ -91,6 +91,7 @@ int init_message(int num_procs, void *header_ptr, void *session)
 
 void get_message(int for_proc, void **msg_data, size_t *msg_size, size_t *bytes_read, void *session)
 {
+   session = session;
    message_t *msg;
    sheep_ptr_t *msgp = proc_messages + for_proc;
    assert(!IS_SHEEP_NULL(msgp));
@@ -103,6 +104,7 @@ void get_message(int for_proc, void **msg_data, size_t *msg_size, size_t *bytes_
 
 int has_message(int for_proc, void *session)
 {
+   session=session;
    sheep_ptr_t *msgp = proc_messages + for_proc;
    return !IS_SHEEP_NULL(msgp);
 }
@@ -209,6 +211,7 @@ int get_message_space(size_t msg_size, unsigned char **msg_space, void **header_
 
 void update_bytes_read(int for_proc, size_t newval, void *session)
 {
+   session=session;
    message_t *msg;
    sheep_ptr_t *msgp = proc_messages + for_proc;
    assert(!IS_SHEEP_NULL(msgp));

--- a/src/biter/demultiplex.h
+++ b/src/biter/demultiplex.h
@@ -22,7 +22,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 typedef struct msg_header_t {
    uint32_t msg_size;
-   uint32_t msg_target;
+   int32_t msg_target;
 } msg_header_t;
 
 extern int test_pipe_lock(void *session);

--- a/src/biter/linux_daemon_ids.c
+++ b/src/biter/linux_daemon_ids.c
@@ -25,6 +25,7 @@ int biterd_num_compute_nodes()
 
 int biterd_ranks_in_cn(int cn_id)
 {
+   cn_id=cn_id;
    char *proc_s = getenv("PROCS");
    if (proc_s)
       return atoi(proc_s);
@@ -34,20 +35,26 @@ int biterd_ranks_in_cn(int cn_id)
 
 int biterd_unique_num_for_cn(int cn_id)
 {
+   cn_id=cn_id;
    return 0;
 }
 
 int biterd_get_rank(int compute_node_id, int client_id)
 {
+   compute_node_id=compute_node_id;
    return client_id;
 }
 
 int biterd_register_rank(int session_id, uint32_t client_id, uint32_t rank)
 {
+   session_id=session_id;
+   client_id=client_id;
+   rank=rank;
    return 0;
 }
 
 int biterd_init_comms(const char *tmpdir)
 {
+   tmpdir=tmpdir;
    return 0;
 }

--- a/src/biter/server_queue.c
+++ b/src/biter/server_queue.c
@@ -45,41 +45,49 @@ void init_queue(int num_procs, void *session)
 
 int test_pipe_lock(void *session)
 {
+   session=session;
    return 1;
 }
 
 int release_pipe_lock(void *session)
 {
+   session=session;
    return 0;
 }
 
 int take_queue_lock(void *session)
 {
+   session=session;
    return 0;
 }
 
 int release_queue_lock(void *session)
 {
+   session=session;
    return 0;
 }
 
 int take_write_lock(void *session)
 {
+   session=session;
    return 0;
 }
 
 int release_write_lock(void *session)
 {
+   session=session;
    return 0;
 }
 
 int take_pipe_lock(void *session)
 {
+   session=session;
    return 0;
 }
 
 void get_message(int for_proc, void **msg_data, size_t *msg_size, size_t *bytes_read, void *session)
 {
+   session=session;
    message_t *msg = PROC_MESSAGES[for_proc];
    assert(msg);
 
@@ -90,6 +98,7 @@ void get_message(int for_proc, void **msg_data, size_t *msg_size, size_t *bytes_
 
 int has_message(int for_proc, void *session)
 {
+   session=session;
    return PROC_MESSAGES[for_proc] != NULL;
 }
 
@@ -124,6 +133,7 @@ int enqueue_message(int for_proc, void *msg_data, size_t msg_size, void *header_
 
 int get_message_space(size_t msg_size, unsigned char **msg_space, void **header_space, void *session)
 {
+   session=session;
    *msg_space = (unsigned char *) malloc(msg_size);
    *header_space = malloc(sizeof(message_t));
    return 0;

--- a/src/biter/shmutil.h
+++ b/src/biter/shmutil.h
@@ -17,18 +17,19 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #if !defined(SHMUTIL_H_)
 #define SHMUTIL_H_
 
+#include <sys/types.h>
 #include "sheep.h"
 #include "spindle_launch.h"
 
 typedef struct {
-   volatile unsigned long *lock;
-   volatile unsigned long *held_by;
+   volatile pid_t *lock;
+   volatile pid_t *held_by;
    int ref_count;
 } lock_t;
 
 typedef struct {
    volatile int cur_id;
-   unsigned long locks[2];
+   pid_t locks[2];
 } base_header_t;
 
 #include "demultiplex.h"
@@ -43,11 +44,11 @@ typedef struct {
    int num_ranks;
    int read_file;
    int num_started;
-   unsigned long locks[6];
+   pid_t locks[6];
 } biter_header_t;
 
 typedef struct {
-   unsigned long locks[2];
+   pid_t locks[2];
    sheep_ptr_t hash;
    sheep_ptr_t lru_head;
    sheep_ptr_t lru_end;

--- a/src/client/auditclient/auditclient.c
+++ b/src/client/auditclient/auditclient.c
@@ -29,6 +29,7 @@ extern void restore_pathpatch();
 
 unsigned int spindle_la_version(unsigned int version)
 {
+   version=version;
    patchDTV_init();
    return 1;
 }
@@ -51,6 +52,8 @@ void spindle_la_activity (uintptr_t *cookie, unsigned int flag)
 
 unsigned int spindle_la_objopen(struct link_map *map, Lmid_t lmid, uintptr_t *cookie)
 {
+   lmid=lmid;
+   cookie=cookie;
    char buffer[4096];
    char *exe_name, *exe_name2;
 
@@ -73,5 +76,6 @@ unsigned int spindle_la_objopen(struct link_map *map, Lmid_t lmid, uintptr_t *co
 
 unsigned int spindle_la_objclose(uintptr_t *cookie)
 {
+   cookie=cookie;
    return 0;
 }

--- a/src/client/auditclient/auditclient_x86_64.c
+++ b/src/client/auditclient/auditclient_x86_64.c
@@ -41,6 +41,10 @@ Elf64_Addr la_x86_64_gnu_pltenter(Elf64_Sym *sym,
                                   const char *symname,
                                   long int *framesizep)
 {
+   ndx=ndx;
+   defcook=defcook;
+   flags=flags;
+   framesizep=framesizep;
    struct link_map *map = get_linkmap_from_cookie(refcook);
    unsigned long reloc_index = *((unsigned long *) (regs->lr_rsp-8));
    Elf64_Addr target = client_call_binding(symname, sym->st_value);
@@ -53,6 +57,9 @@ uintptr_t la_symbind64(Elf64_Sym *sym, unsigned int ndx,
 {
 //   struct link_map *rmap = get_linkmap_from_cookie(refcook);
 //   struct link_map *dmap = get_linkmap_from_cookie(defcook);
+   ndx=ndx;
+   refcook=refcook;
+   defcook=defcook;
    updateDataBindingQueue(0);
    Elf64_Addr target = client_call_binding(symname, sym->st_value);
    *flags = 0;

--- a/src/client/auditclient/bindgot.c
+++ b/src/client/auditclient/bindgot.c
@@ -131,6 +131,7 @@ Elf64_Addr doPermanentBinding_noidx(uintptr_t *refcook, uintptr_t *defcook,
                                     Elf64_Addr target, const char *symname,
                                     void *stack_begin, void *stack_end)
 {
+   defcook=defcook;
    int plt_reloc_idx;
    Elf64_Rela *rels = NULL, *rel;
    Elf64_Xword relsize = 0;
@@ -247,6 +248,7 @@ Elf64_Addr doPermanentBinding_idx(struct link_map *map,
                                   Elf64_Addr target,
                                   const char *symname)
 {
+   symname=symname;
    Elf64_Dyn *dynamic_section = map->l_ld;
    Elf64_Addr *got_entry;
    Elf64_Rela *rel = NULL;

--- a/src/client/auditclient/writablegot.c
+++ b/src/client/auditclient/writablegot.c
@@ -68,6 +68,7 @@ int add_wgot_library(struct link_map *map)
    unsigned long rel_size = 0, relent_size = 0, relcount = 0, plt_gotsize = 0, start, end;
    unsigned long datarels_size = 0, largest_datarel_target = 0, smallest_datarel_target = 0;
    signed int i;
+   unsigned long j;
    struct got_range_t *tmprange;
    
 
@@ -118,9 +119,9 @@ int add_wgot_library(struct link_map *map)
    plt_gotsize = (relcount + EXTRA_GOT_ENTRIES + 1) * sizeof(void*);
 
    if (datarels) {
-      for (i = 0; i < datarels_size / relent_size; i++) {
-         unsigned long target = datarels[i].r_offset + map->l_addr;
-         if (ELF64_R_TYPE(datarels[i].r_info) != DATA_GOT_TYPE)
+      for (j = 0; j < datarels_size / relent_size; j++) {
+         unsigned long target = datarels[j].r_offset + map->l_addr;
+         if (ELF64_R_TYPE(datarels[j].r_info) != DATA_GOT_TYPE)
             continue;
          largest_datarel_target = MAX(target, largest_datarel_target);
          if (!smallest_datarel_target) smallest_datarel_target = target;

--- a/src/client/beboot/spindle_bootstrap.c
+++ b/src/client/beboot/spindle_bootstrap.c
@@ -282,6 +282,7 @@ static void get_clientlib()
 
 void test_log(const char *name)
 {
+    name=name;
 }
 
 static int handle_exec_failure(char **cmdline, int errno_val)

--- a/src/client/client/client.c
+++ b/src/client/client/client.c
@@ -90,6 +90,8 @@ static char *concatStrings(const char *str1, const char *str2)
 static int find_libs_iterator(struct dl_phdr_info *lib,
                               size_t size, void *data)
 {
+   size=size;
+   data=data;
    if (!libc_name && (strstr(lib->dlpi_name, "libc.") || strstr(lib->dlpi_name, "libc-"))) {
       libc_name = lib->dlpi_name;
       libc_phdrs = lib->dlpi_phdr;

--- a/src/client/client/intercept_readlink.c
+++ b/src/client/client/intercept_readlink.c
@@ -118,7 +118,7 @@ ssize_t readlink_wrapper(const char *path, char *buf, size_t bufsiz)
    if (len > bufsiz)
       len = bufsiz;
    memcpy(buf, resultpath, len);
-   debug_printf2("spindle readlink translated %s to %.*s with len %d\n", path, len, buf, len);
+   debug_printf2("spindle readlink translated %s to %.*s with len %zu\n", path, (int)len, buf, len);
    return len;
 }
 
@@ -149,6 +149,6 @@ ssize_t readlinkat_wrapper(int dirfd, const char *path, char *buf, size_t bufsiz
    if (len > bufsiz)
       len = bufsiz;
    memcpy(buf, newbuf, len);
-   debug_printf2("spindle readlink translated %s to %.*s with len %d\n", path, len, newbuf, len);
+   debug_printf2("spindle readlink translated %s to %.*s with len %zu\n", path, (int)len, newbuf, len);
    return (ssize_t) len;
 }

--- a/src/client/client/intercept_readlink.c
+++ b/src/client/client/intercept_readlink.c
@@ -56,7 +56,8 @@ static int fix_local_readlink(char *buf, size_t bufsiz)
 ssize_t readlink_wrapper(const char *path, char *buf, size_t bufsiz)
 {
    char resultpath[MAX_PATH_LEN+1];
-   int intercept_result, result, len, readlink_errcode;
+   int intercept_result, result, readlink_errcode;
+   size_t len;
    ssize_t rl_result;
 
    check_for_fork();
@@ -125,7 +126,8 @@ ssize_t readlinkat_wrapper(int dirfd, const char *path, char *buf, size_t bufsiz
 {
    char newbuf[MAX_PATH_LEN+1];
    ssize_t rl_result;
-   int result, len;
+   size_t len;
+   int result;
    
    debug_printf2("Intercepted readlinkat on %s\n", path);
 

--- a/src/client/client/intercept_stat.c
+++ b/src/client/client/intercept_stat.c
@@ -261,6 +261,7 @@ int rtcache_fxstat64(int vers, int fd, struct stat *buf)
 static int *ldso_errno;
 int ldso_xstat(int ver, const char *filename, struct stat *buf)
 {
+   ver=ver;
    int result;
    result = handle_stat(filename, buf, FROM_LDSO);
    if (result != 0) {
@@ -273,6 +274,7 @@ int ldso_xstat(int ver, const char *filename, struct stat *buf)
 
 int ldso_lxstat(int ver, const char *filename, struct stat *buf)
 {
+   ver=ver;
    int result;
    result = handle_stat(filename, buf, FROM_LDSO | IS_LSTAT);   
    if (result != 0) {

--- a/src/client/client/realpath.c
+++ b/src/client/client/realpath.c
@@ -347,7 +347,7 @@ realpath_stk (const char *name, char *resolved, struct realpath_bufs *bufs)
 
       /* Length of this file name component; it can be zero if a file
          name ends in '/'.  */
-      long startlen = end - start;
+      size_t startlen = end - start;
 
       if (startlen == 0)
          break;
@@ -365,7 +365,7 @@ realpath_stk (const char *name, char *resolved, struct realpath_bufs *bufs)
          if (!ISSLASH (dest[-1]))
             *dest++ = '/';
 
-         while (rname + bufs->rname.length - dest
+         while ( (size_t)(rname + bufs->rname.length - dest)
                 < startlen + sizeof dir_suffix)
          {
             long dest_offset = dest - rname;

--- a/src/client/client/remap_exec.c
+++ b/src/client/client/remap_exec.c
@@ -37,11 +37,12 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 static int pagesize;
 
-static int fetchPhdrs(ElfW(Addr) *aout_base, ElfW(Phdr) **phdrs, unsigned int *phdrs_size)
+static int fetchPhdrs(ElfW(Addr) *aout_base, ElfW(Phdr) **phdrs, size_t *phdrs_size)
 {
    pid_t pid;
    char auxvpath[64];
-   int fd = 0, result, i;
+   int fd = 0, result;
+   size_t i;
    ElfW(auxv_t) auxv;
    ElfW(Phdr) *phdr;
    ElfW(Addr) phdr_offset = 0;
@@ -104,7 +105,7 @@ static int fetchPhdrs(ElfW(Addr) *aout_base, ElfW(Phdr) **phdrs, unsigned int *p
 
    *aout_base = (ElfW(Addr)) (((unsigned long) *phdrs) - phdr_offset);
 
-   debug_printf("Remapping a.out.  %u program headers at %p.  Program base at %lx\n",
+   debug_printf("Remapping a.out.  %zu program headers at %p.  Program base at %lx\n",
                 *phdrs_size, *phdrs, (unsigned long) *aout_base);
 
    return 0;
@@ -169,7 +170,7 @@ void remap_executable(int ldcsid)
 {
    ElfW(Addr) aout_base;
    ElfW(Phdr) *phdrs, *p;
-   unsigned int phdrs_size, i;
+   size_t phdrs_size, i;
    int result;
    int exe_fd;
 

--- a/src/client/client/should_intercept.c
+++ b/src/client/client/should_intercept.c
@@ -76,7 +76,7 @@ static int is_python_path(const char *pathname)
    return 0;
 }
 
-static int is_python(const char *pathname, char *last_dot)
+static int is_python(const char * const last_dot)
 {
    if (last_dot &&
        (strcmp(last_dot, ".py") == 0 ||
@@ -86,7 +86,7 @@ static int is_python(const char *pathname, char *last_dot)
    return 0;
 }
 
-static int is_compiled_python(const char *pathname, char *last_dot)
+static int is_compiled_python(const char * const last_dot)
 {
    if (last_dot &&
        (strcmp(last_dot, ".pyc") == 0 ||
@@ -95,7 +95,7 @@ static int is_compiled_python(const char *pathname, char *last_dot)
    return 0;
 }
 
-static int is_dso(const char *pathname, char *last_slash, char *last_dot)
+static int is_dso(const char * const last_slash, const char * const last_dot)
 {
    if (last_dot &&
        strcmp(last_dot, ".so") == 0)
@@ -163,13 +163,13 @@ int open_filter(const char *fname, int flags)
    if (is_python_path(fname) && !open_for_dir(flags))
       return REDIRECT;
 
-   if (!open_for_write(flags) && is_dso(fname, last_slash, last_dot))
+   if (!open_for_write(flags) && is_dso(last_slash, last_dot))
       return REDIRECT;
 
-   if (open_for_excl(flags) && is_compiled_python(fname, last_dot))
+   if (open_for_excl(flags) && is_compiled_python(last_dot))
       return EXCL_OPEN;
 
-   if (!open_for_write(flags) && is_python(fname, last_dot))
+   if (!open_for_write(flags) && is_python(last_dot))
       return REDIRECT;
 
    return ORIG_CALL;
@@ -205,13 +205,13 @@ int fopen_filter(const char *fname, const char *flags)
    if (is_python_path(fname))
       return REDIRECT;
 
-   if (!open_for_write(flags) && is_dso(fname, last_slash, last_dot))
+   if (!open_for_write(flags) && is_dso(last_slash, last_dot))
       return REDIRECT;
 
-   if (open_for_excl(flags) && is_compiled_python(fname, last_dot))
+   if (open_for_excl(flags) && is_compiled_python(last_dot))
       return EXCL_OPEN;
 
-   if (!open_for_write(flags) && is_python(fname, last_dot))
+   if (!open_for_write(flags) && is_python(last_dot))
       return REDIRECT;
 
    return ORIG_CALL;
@@ -264,8 +264,8 @@ int stat_filter(const char *fname)
    last_dot = strrchr(fname, '.');
    last_slash = strrchr(fname, '/');
 
-   if (is_dso(fname, last_slash, last_dot) ||
-       is_python(fname, last_dot) || 
+   if (is_dso(last_slash, last_dot) ||
+       is_python(last_dot) || 
        is_lib_prefix(fname, last_slash))
       return REDIRECT;
    else

--- a/src/client/client_comlib/client_api.c
+++ b/src/client/client_comlib/client_api.c
@@ -57,7 +57,7 @@ int send_file_query(int fd, char* path, int dso, char** newpath, int *errcode) {
 
    COMM_LOCK;
 
-   debug_printf3("sending message of type: file_query len=%d data='%s' ...(%s)\n",
+   debug_printf3("sending message of type: file_query len=%zu data='%s' ...(%s)\n",
                  message.header.len, message.data, path);  
    client_send_msg(fd, &message);
 
@@ -105,7 +105,7 @@ int send_stat_request(int fd, char *path, int is_lstat, char *newpath)
    
    COMM_LOCK;
 
-   debug_printf3("sending message of type: %sstat_query len=%d data='%s' ...(%s)\n",
+   debug_printf3("sending message of type: %sstat_query len=%zu data='%s' ...(%s)\n",
                  is_lstat ? "l" : "", message.header.len, message.data, path);  
    client_send_msg(fd, &message);
 
@@ -149,7 +149,7 @@ int send_existance_test(int fd, char *path, int *exists)
    message.header.len = strlen(path) + 1;
    message.data = (void *) buffer;
 
-   debug_printf3("Sending message of type: file_exist_query len=%d, data=%s\n",
+   debug_printf3("Sending message of type: file_exist_query len=%zu, data=%s\n",
                  message.header.len, path);
    COMM_LOCK;
 
@@ -186,7 +186,7 @@ int send_orig_path_request(int fd, const char *path, char *newpath)
    message.header.len = strlen(path) + 1;
    message.data = (void *) buffer;
 
-   debug_printf3("Sending message of type: file_orig_path len=%d, data=%s\n",
+   debug_printf3("Sending message of type: file_orig_path len=%zu, data=%s\n",
                  message.header.len, path);
    COMM_LOCK;
 
@@ -210,7 +210,7 @@ int send_dirlists_request(int fd, char **local_result, char **exece_result, char
    ldcs_message_t message;
    int local_len, ee_len;
    char *buffer;
-   int buffer_pos = 0;
+   size_t buffer_pos = 0;
    
    message.header.type = LDCS_MSG_DIRLISTS_REQ;
    message.header.len = 0;

--- a/src/client/client_comlib/client_api.c
+++ b/src/client/client_comlib/client_api.c
@@ -208,7 +208,7 @@ int send_orig_path_request(int fd, const char *path, char *newpath)
 int send_dirlists_request(int fd, char **local_result, char **exece_result, char **to_free)
 {
    ldcs_message_t message;
-   int local_len, ee_len;
+   size_t local_len, ee_len;
    char *buffer;
    size_t buffer_pos = 0;
    
@@ -221,17 +221,25 @@ int send_dirlists_request(int fd, char **local_result, char **exece_result, char
    client_recv_msg_dynamic(fd, &message, LDCS_READ_BLOCK);
    COMM_UNLOCK;
 
+   debug_printf("QQQ After client_recv_msg_dynamic, message.header.len=%zu.\n", message.header.len);
+   debug_printf("QQQ After buffer_pos initialized, buffer_pos=%zu.\n", buffer_pos);
+
    buffer = (char *) message.data;
    memcpy(&local_len, buffer+buffer_pos, sizeof(local_len));
    buffer_pos += sizeof(local_len);
    if (local_result)
       *local_result = buffer+buffer_pos;
    buffer_pos += local_len;
+   debug_printf("QQQ After buffer_pos += local_len, buffer_pos=%zu.\n", buffer_pos);
    memcpy(&ee_len, buffer+buffer_pos, sizeof(ee_len));
    buffer_pos += sizeof(ee_len);
+   debug_printf("QQQ After buffer_pos += sizeof(ee_len), buffer_pos=%zu.\n", buffer_pos);
    if (exece_result)
       *exece_result = buffer+buffer_pos;
    buffer_pos += ee_len;
+   debug_printf("QQQ After buffer_pos += ee_len, buffer_pos=%zu.\n", buffer_pos);
+
+   debug_printf("QQQ After parsing message, buffer_pos=%zu.\n", buffer_pos);
    assert(buffer_pos == message.header.len);
 
    *to_free = buffer;

--- a/src/client/client_comlib/client_api_biter.c
+++ b/src/client/client_comlib/client_api_biter.c
@@ -34,6 +34,7 @@ extern unsigned int shm_cachesize;
 
 int client_open_connection_biter(char* location, number_t number)
 {
+   number=number;
    debug_printf3("Calling biterc_newsession(%s, %lu)\n", location, (unsigned long) shm_cachesize);
    session = biterc_newsession(location, shm_cachesize);
    if (session == -1) {
@@ -55,11 +56,13 @@ int client_close_connection_biter(int connid)
 
 int client_register_connection_biter(char *connection_str)
 {
+   connection_str = connection_str;
    return 0;
 }
 
 char *client_get_connection_string_biter(int fd)
 {
+   fd = fd;
    return NULL;
 }
 
@@ -72,7 +75,7 @@ int client_send_msg_biter(int connid, ldcs_message_t *msg)
       return -1;
    }
 
-   debug_printf3("sending message of size len=%d\n", msg->header.len);
+   debug_printf3("sending message of size len=%zu\n", msg->header.len);
 
    result = biterc_write(connid, &msg->header, sizeof(msg->header));
    if (result == -1) {
@@ -146,5 +149,6 @@ int client_recv_msg_dynamic_biter(int fd, ldcs_message_t *msg, ldcs_read_block_t
 
 int is_client_fd(int connid, int fd)
 {
+   connid = connid;
    return biterc_is_client_fd(session, fd);
 }

--- a/src/client/client_comlib/client_api_pipe.c
+++ b/src/client/client_comlib/client_api_pipe.c
@@ -197,6 +197,7 @@ int client_open_connection_pipe(char* location, number_t number)
    char ready[MAX_PATH_LEN];
    int find_r_fd = 0, find_w_fd = 0;
 
+   number=number;
    debug_printf("Client creating pipe for connection to server\n");
    fd = get_new_fd_pipe();
    if (fd < 0) 
@@ -320,7 +321,7 @@ int client_send_msg_pipe(int fd, ldcs_message_t *msg) {
 
    assert(fd >= 0 && fd < MAX_FD);
    
-   debug_printf3("sending message of size len=%d\n", msg->header.len);
+   debug_printf3("sending message of size len=%zu\n", msg->header.len);
    
    result = write_pipe(fdlist_pipe[fd].out_fd, &msg->header, sizeof(msg->header));
    if (result == -1)
@@ -360,7 +361,7 @@ static int client_recv_msg_pipe(int fd, ldcs_message_t *msg, ldcs_read_block_t b
       msg->data = (char *) spindle_malloc(msg->header.len);
    }
 
-   debug_printf3("Reading %d bytes for payload from pipe\n", msg->header.len);
+   debug_printf3("Reading %zu bytes for payload from pipe\n", msg->header.len);
    result = read_pipe(fdlist_pipe[fd].in_fd, msg->data, msg->header.len);
    return result;
 }

--- a/src/client/client_comlib/client_api_socket.c
+++ b/src/client/client_comlib/client_api_socket.c
@@ -42,10 +42,10 @@ static int get_new_fd_socket()
    return 0;
 }
 
-static int _ldcs_read_socket(int fd, void *data, int bytes, ldcs_read_block_t block) {
+static size_t _ldcs_read_socket(int fd, void *data, int bytes, ldcs_read_block_t block) {
 
-  int         left,bsumread;
-  ssize_t      btoread, bread;
+  size_t     left,bsumread,btoread;
+  ssize_t    bread;
   char       *dataptr;
   
   left      = bytes;
@@ -57,14 +57,16 @@ static int _ldcs_read_socket(int fd, void *data, int bytes, ldcs_read_block_t bl
     bread      = read(fd, dataptr, btoread);
     if(bread<0) {
       if( (errno==EAGAIN) || (errno==EWOULDBLOCK) ) {
-	debug_printf3("read from socket: got EAGAIN or EWOULDBLOCK\n");
-	if(block==LDCS_READ_NO_BLOCK) return(0);
-	else continue;
+	    debug_printf3("read from socket: got EAGAIN or EWOULDBLOCK\n");
+	    if(block==LDCS_READ_NO_BLOCK)
+          return(0);
+	    else continue;
       } else { 
-         debug_printf3("read from socket: %ld bytes ... errno=%d (%s)\n",bread,errno,strerror(errno));
+         debug_printf3("read from socket: %zd bytes ... errno=%d (%s)\n",bread,errno,strerror(errno));
+         return 0;
       }
     } else {
-      debug_printf3("read from socket: %ld bytes ...\n",bread);
+      debug_printf3("read from socket: %zd bytes ...\n",bread);
     }
 
     if(bread>0) {
@@ -73,7 +75,7 @@ static int _ldcs_read_socket(int fd, void *data, int bytes, ldcs_read_block_t bl
       bsumread  += bread;
     } else {
       if(bread==0) return(bsumread);
-      else         return(bread);
+      else         return( (size_t)bread );
     }
   }
   return (bsumread);
@@ -198,7 +200,7 @@ int client_send_msg_socket(int fd, ldcs_message_t * msg) {
   connfd=ldcs_socket_fdlist[fd].fd;
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("sending message of type: %s len=%d data=%s ...\n",
+  debug_printf3("sending message of type: %s len=%zu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
 
@@ -217,14 +219,14 @@ int client_send_msg_socket(int fd, ldcs_message_t * msg) {
 int client_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_t block) {
   char help[41];
   int rc=0;
-  int n, connfd;
+  int connfd;
+  size_t n;
   if ((fd<0) || (fd>MAX_FD) )  _error("wrong fd");
   connfd=ldcs_socket_fdlist[fd].fd;
 
 
   n = _ldcs_read_socket(connfd,&msg->header,sizeof(msg->header), block);
   if (n == 0) return(rc);
-  if (n < 0) _error("ERROR reading header from socket");
 
   if(msg->header.len>0) {
 
@@ -233,7 +235,6 @@ int client_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_
     
     n = _ldcs_read_socket(connfd,msg->data,msg->header.len, LDCS_READ_BLOCK);
     if (n == 0) return(rc);
-    if (n < 0) _error("ERROR reading message data from socket");
     if (n != msg->header.len) _error("received different number of bytes for message data");
 
   } else {
@@ -241,7 +242,7 @@ int client_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_
   }
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("received message of type: %s len=%d data=%s ...\n",
+  debug_printf3("received message of type: %s len=%zu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
   

--- a/src/client/ldsolookup/print_ldso_entry.c
+++ b/src/client/ldsolookup/print_ldso_entry.c
@@ -10,6 +10,7 @@
 
 int main(int argc, char *argv[])
 {
+   argc=argc;
    ElfW(Dyn) *dyn;
    ElfW(Addr) *pltgot = NULL;
    char path[4097];

--- a/src/client/subaudit/subaudit.c
+++ b/src/client/subaudit/subaudit.c
@@ -27,6 +27,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 unsigned int spindle_la_version(unsigned int version)
 {
+   version=version;
    int result;
    int binding_offset = 0;
 
@@ -55,12 +56,16 @@ static void bind_to_libc()
 
 void spindle_la_activity(uintptr_t *cookie, unsigned int flag)
 {
+   cookie=cookie;
+   flag=flag;
    bind_to_libc();
    update_plt_bindings();
 }
 
 unsigned int spindle_la_objopen(struct link_map *map, Lmid_t lmid, uintptr_t *cookie)
 {
+   lmid=lmid;
+   cookie=cookie;
    bind_to_libc();
    add_library_to_plt_update_list(map);
    return 0;

--- a/src/client/subaudit/update_pltbind.c
+++ b/src/client/subaudit/update_pltbind.c
@@ -178,7 +178,8 @@ void add_library_to_plt_update_list(struct link_map *lmap)
 
 void remove_library_from_plt_update_list(struct link_map *lmap)
 {
-   int i, found = -1;
+   unsigned int i;
+   int found = -1;
    if (!update_list_cur)
       return;
 

--- a/src/cobo/cobo.c
+++ b/src/cobo/cobo.c
@@ -474,7 +474,7 @@ static int cobo_connect_hostname(char* hostname, int rank)
     if (!he) {
        /* gethostbyname doesn't know how to resolve hostname, trying inet_addr */ 
        saddr.s_addr = inet_addr(hostname);
-       if (saddr.s_addr == -1) {
+       if (saddr.s_addr == (in_addr_t)-1) {
            err_printf("Hostname lookup failed (gethostbyname(%s) %s h_errno=%d)\n",
                 hostname, hstrerror(h_errno), h_errno);
            return s;
@@ -1345,6 +1345,9 @@ int cobo_allgather(void* sendbuf, int sendcount, void* recvbuf)
  */
 int cobo_alltoall(void* sendbuf, int sendcount, void* recvbuf)
 {
+    sendbuf=sendbuf;
+    sendcount=sendcount;
+    recvbuf=recvbuf;
     struct timeval start, end;
     cobo_gettimeofday(&start);
     debug_printf3("Starting cobo_alltoall()");

--- a/src/cobo/handshake.c
+++ b/src/cobo/handshake.c
@@ -106,7 +106,7 @@ static char *last_error_message = NULL;
 static char *last_security_message = NULL;
 static unsigned char *saved_key;
 static char *saved_key_filepath;
-static unsigned int saved_key_len;
+static size_t saved_key_len;
 static connection_info_t *saved_conninfo;
 static int timeout_seconds = 0;
 
@@ -122,7 +122,7 @@ static int none_encrypt_packet(handshake_packet_t *packet,
                                unsigned char **packet_buffer, size_t *packet_buffer_size);
 static int munge_encrypt_packet(handshake_packet_t *packet, 
                                 unsigned char **packet_buffer, size_t *packet_buffer_size);
-static int filekey_encrypt_packet(char *key_filepath, int key_length_bytes,
+static int filekey_encrypt_packet(char *key_filepath, size_t key_length_bytes,
                                   handshake_packet_t *packet, 
                                   unsigned char **packet_buffer, size_t *packet_buffer_size);
 static int key_encrypt_packet(unsigned char *key, int key_length_bytes,
@@ -147,9 +147,9 @@ static int handshake_wrapper(int sockfd, handshake_protocol_t *hdata, uint64_t s
                              int is_server);
 static int handshake_main(int sockfd, handshake_protocol_t *hdata, uint64_t session_id,
                           int is_server);
-static int reliable_write(int fd, const void *buf, size_t size);
-static int reliable_read(int fd, void *buf, size_t size);
-static int read_key(char *key_filepath, int key_length_bytes);
+static size_t reliable_write(int fd, const void *buf, size_t size, int *err);
+static size_t reliable_read(int fd, void *buf, size_t size, int *err);
+static int read_key(char *key_filepath, size_t key_length_bytes);
 static int share_result(int fd, int result);
 static int get_client_server_addrs(int sockfd, int i_am_server, connection_info_t *conninfo);
 static int send_packet(int sockfd, unsigned char *packet, unsigned int packet_size);
@@ -444,14 +444,14 @@ static int encrypt_packet(handshake_protocol_t *hdata, handshake_packet_t *packe
          debug_printf("Server encrypting packet with munge\n");
          return munge_encrypt_packet(packet, packet_buffer, packet_buffer_size);
       case hs_key_in_file:
-         debug_printf("Server encrypting packet with key of size %d from file %s\n",
+         debug_printf("Server encrypting packet with key of size %zu from file %s\n",
                       hdata->data.key_in_file.key_length_bytes,
                       hdata->data.key_in_file.key_filepath);
          return filekey_encrypt_packet(hdata->data.key_in_file.key_filepath,
                                        hdata->data.key_in_file.key_length_bytes,
                                        packet, packet_buffer, packet_buffer_size);
       case hs_explicit_key:
-         debug_printf("Server encrypting packet with provided key of size %d\n",
+         debug_printf("Server encrypting packet with provided key of size %zu\n",
                       hdata->data.explicit_key.key_length_bytes);
          return key_encrypt_packet(hdata->data.explicit_key.key,
                                    hdata->data.explicit_key.key_length_bytes,
@@ -470,6 +470,9 @@ static int none_encrypt_packet(handshake_packet_t *packet,
    memcpy(*packet_buffer, packet, *packet_buffer_size);
    return 0;
 #else
+   packet=packet;
+   packet_buffer=packet_buffer;
+   packet_buffer_size=packet_buffer_size;
    error_printf("Null encryption must be explicitly enabled\n");
    return HSHAKE_INTERNAL_ERROR;
 #endif
@@ -543,9 +546,10 @@ static int munge_encrypt_packet(handshake_packet_t *packet,
 #endif
 }
 
-static int read_key(char *key_filepath, int key_length_bytes)
+static int read_key(char *key_filepath, size_t key_length_bytes)
 {
-   int result, fd = -1;
+   int err, fd = -1, rc;
+   size_t result;
    struct stat st;
    int return_result;
    uid_t uid = getuid();
@@ -573,8 +577,8 @@ static int read_key(char *key_filepath, int key_length_bytes)
       goto done;
    }
 
-   result = fstat(fd, &st);
-   if (result == -1) {
+   rc = fstat(fd, &st);
+   if (rc == -1) {
       security_error_printf("Unable to access keyfile %s: %s\n", key_filepath, strerror(errno));
       return_result = HSHAKE_ABORT;
       goto done;
@@ -601,7 +605,7 @@ static int read_key(char *key_filepath, int key_length_bytes)
       goto done;
    }
    
-   if (st.st_size != key_length_bytes) {
+   if (st.st_size != (off_t)key_length_bytes) {
       security_error_printf("Size on key file %s is %lu and does not match expected size of %lu\n",
                             key_filepath, (unsigned long) st.st_size, (unsigned long) key_length_bytes);
       return_result = HSHAKE_ABORT;
@@ -610,8 +614,8 @@ static int read_key(char *key_filepath, int key_length_bytes)
 
    buffer = malloc(key_length_bytes);
    assert(buffer);
-   result = reliable_read(fd, buffer, key_length_bytes);
-   if (result != key_length_bytes) {
+   result = reliable_read(fd, buffer, key_length_bytes, &err);
+   if (err || result != key_length_bytes) {
       security_error_printf("Unable to read from key file %s: %s\n", key_filepath, strerror(errno));
       return_result = HSHAKE_ABORT;
       goto done;
@@ -631,7 +635,7 @@ static int read_key(char *key_filepath, int key_length_bytes)
    return return_result;
 }
 
-static int filekey_encrypt_packet(char *key_filepath, int key_length_bytes,
+static int filekey_encrypt_packet(char *key_filepath, size_t key_length_bytes,
                                   handshake_packet_t *packet, 
                                   unsigned char **packet_buffer, size_t *packet_buffer_size)
 {
@@ -732,15 +736,21 @@ static int key_encrypt_packet(unsigned char *key, int key_length_bytes,
 
    return 0;   
 #else
+   key=key;
+   key_length_bytes=key_length_bytes;
+   packet=packet;
+   packet_buffer=packet_buffer;
+   packet_buffer_size=packet_buffer_size;
    error_printf("Handshake not built against gcrypt\n");
    return HSHAKE_INTERNAL_ERROR;
 #endif   
 }
 
-static int reliable_write(int fd, const void *buf, size_t size)
+static size_t reliable_write(int fd, const void *buf, size_t size, int *err)
 {
    int result;
    size_t bytes_written = 0;
+   *err = HSHAKE_SUCCESS;
 
    while (bytes_written < size) {
       result = write(fd, ((unsigned char *) buf) + bytes_written, size - bytes_written);
@@ -748,7 +758,8 @@ static int reliable_write(int fd, const void *buf, size_t size)
          continue;
       else if (result == -1) {
          error_printf("Error writing to socket: %s\n", strerror(errno));
-         return -1;
+         *err = HSHAKE_INTERNAL_ERROR;
+         return 0;
       }
       else
          bytes_written += result;
@@ -756,10 +767,11 @@ static int reliable_write(int fd, const void *buf, size_t size)
    return bytes_written;
 }
 
-static int reliable_read(int fd, void *buf, size_t size)
+static size_t reliable_read(int fd, void *buf, size_t size, int *err)
 {
    int result;
    size_t bytes_read = 0;
+   *err = HSHAKE_SUCCESS;
 
    while (bytes_read < size) {
       if (timeout_seconds) {
@@ -773,15 +785,18 @@ static int reliable_read(int fd, void *buf, size_t size)
          result = select(fd+1, &rfd_set, NULL, NULL, &timeout);
          if (result == -1) {
             error_printf("Error select'ing on socket fd: %s\n", strerror(errno));
-            return HSHAKE_INTERNAL_ERROR;
+            *err = HSHAKE_INTERNAL_ERROR;
+            return 0;
          }
          else if (result == 0) {
             error_printf("Timed out waiting for read from peer\n");
-            return HSHAKE_INTERNAL_ERROR;
+            *err = HSHAKE_INTERNAL_ERROR;
+            return 0;
          }
          else if (result != 1) {
             error_printf("Unexpected return code of %d from select\n", result);
-            return HSHAKE_INTERNAL_ERROR;            
+            *err = HSHAKE_INTERNAL_ERROR;
+            return 0;            
          }        
       }
       result = read(fd, ((unsigned char *) buf) + bytes_read, size - bytes_read);
@@ -840,6 +855,9 @@ static int none_decrypt_packet(handshake_packet_t *expected_packet,
    memcpy(&recvd_packet, recvd_buffer, recvd_buffer_size);
    return compare_packets(expected_packet, &recvd_packet);
 #else
+   expected_packet=expected_packet;
+   recvd_buffer=recvd_buffer;
+   recvd_buffer_size=recvd_buffer_size;
    error_printf("Null encryption must be explicitly enabled\n");
    return HSHAKE_INTERNAL_ERROR;
 #endif
@@ -849,6 +867,7 @@ static int munge_decrypt_packet(handshake_packet_t *expected_packet,
                                 unsigned char *recvd_buffer, size_t recvd_buffer_size)
 {
 #if defined(MUNGE)
+   recvd_buffer_size=recvd_buffer_size;
    munge_err_t result;
    munge_ctx_t ctx = NULL;
    void *payload = NULL;
@@ -936,6 +955,9 @@ static int munge_decrypt_packet(handshake_packet_t *expected_packet,
    return return_result;
    
 #else
+   expected_packet=expected_packet;
+   recvd_buffer=recvd_buffer;
+   recvd_buffer_size=recvd_buffer_size;
    error_printf("Handshake not compiled with munge support\n");
    return HSHAKE_INTERNAL_ERROR;
 #endif
@@ -993,6 +1015,11 @@ static int key_decrypt_packet(unsigned char *key, unsigned int key_len,
    
    return return_result;
 #else
+   key=key;
+   key_len=key_len;
+   expected_packet=expected_packet;
+   recvd_buffer=recvd_buffer;
+   recvd_buffer_size=recvd_buffer_size;
    error_printf("handshake was not compiled with gcrypt support");
    return HSHAKE_INTERNAL_ERROR;
 #endif
@@ -1063,7 +1090,8 @@ static int compare_packets(handshake_packet_t *expected_packet,
 static int share_result(int fd, int handshake_result)
 {
    int32_t result_to_send, peer_result;
-   int result;
+   size_t result;
+   int err=0;
 
    switch (handshake_result) {
       case HSHAKE_SUCCESS:
@@ -1081,17 +1109,17 @@ static int share_result(int fd, int handshake_result)
     
    debug_printf("Sharing handshake result %d with peer\n", result_to_send);
       
-   result = reliable_write(fd, &result_to_send, sizeof(result_to_send));
-   if (result != sizeof(result_to_send)) {
+   result = reliable_write(fd, &result_to_send, sizeof(result_to_send), &err);
+   if ( err || result != sizeof(result_to_send)) {
       error_printf("Failed to send result of connection\n");
       return HSHAKE_INTERNAL_ERROR;
    }
    
    debug_printf("Reading peer result\n");
-   result = reliable_read(fd, &peer_result, sizeof(peer_result));
-   if (result != sizeof(peer_result)) {
+   result = reliable_read(fd, &peer_result, sizeof(peer_result), &err);
+   if (err || result != sizeof(peer_result)) {
       debug_printf("Failed to read handshake result from peer\n");
-      return result;
+      return err;
    }
    debug_printf("Peer reported result of %d\n", peer_result);
 
@@ -1139,20 +1167,21 @@ static int get_client_server_addrs(int sockfd, int i_am_server,
 static int exchange_sig(int sockfd) 
 {
    uint32_t sig = SIG;
-   int result;
+   size_t result;
+   int err;
 
    debug_printf("Sending sig %x on network\n", sig);
-   result = reliable_write(sockfd, &sig, sizeof(sig));
-   if (result != sizeof(sig)) {
+   result = reliable_write(sockfd, &sig, sizeof(sig), &err);
+   if (err || result != sizeof(sig)) {
       debug_printf("Problem writing sig on network\n");
       return HSHAKE_DROP_CONNECTION;
    }
 
    debug_printf("Receiving sig from network\n");
-   result = reliable_read(sockfd, &sig, sizeof(sig));
-   if (result != sizeof(sig)) {
+   result = reliable_read(sockfd, &sig, sizeof(sig), &err);
+   if (err || result != sizeof(sig)) {
       debug_printf("Problem reading sig from network\n");
-      return result;
+      return err;
    }
    if (sig != SIG) {
       error_printf("Signature %x doesn't match expected value %x\n", sig, SIG);
@@ -1165,18 +1194,19 @@ static int exchange_sig(int sockfd)
 static int send_packet(int sockfd, unsigned char *packet, unsigned int packet_size)
 {
    uint32_t size;
-   int result;
+   size_t result;
+   int err;
 
    debug_printf("Sending packet size on network\n");
    size = packet_size;
-   result = reliable_write(sockfd, &size, sizeof(size));
-   if (result != sizeof(size)) {
+   result = reliable_write(sockfd, &size, sizeof(size), &err);
+   if ( err || result != sizeof(size)) {
       debug_printf("Problem writing packet size on network\n");
       return HSHAKE_INTERNAL_ERROR;
    }
 
    debug_printf("Sending packet on network\n");
-   result = reliable_write(sockfd, packet, packet_size);
+   result = reliable_write(sockfd, packet, packet_size, &err);
    if (result != packet_size) {
       debug_printf("Problem writing packet on network\n");
       return HSHAKE_INTERNAL_ERROR;
@@ -1188,13 +1218,14 @@ static int send_packet(int sockfd, unsigned char *packet, unsigned int packet_si
 static int recv_packet(int sockfd, unsigned char **packet, size_t *packet_size)
 {
    uint32_t size;
-   int result;
+   size_t result;
+   int err;
 
    debug_printf("Receiving packet size from network\n");
-   result = reliable_read(sockfd, &size, sizeof(size));
-   if (result != sizeof(size)) {
+   result = reliable_read(sockfd, &size, sizeof(size), &err);
+   if (err || result != sizeof(size)) {
       debug_printf("Error reading packet size from network\n");
-      return result;
+      return err;
    }
    debug_printf("Received packet size %u\n", (unsigned int) size);
    if (size > 0x100000) {
@@ -1203,10 +1234,10 @@ static int recv_packet(int sockfd, unsigned char **packet, size_t *packet_size)
    }
    *packet = malloc(size);
    assert(*packet);
-   result = reliable_read(sockfd, *packet, size);
-   if (result != size) {
+   result = reliable_read(sockfd, *packet, size, &err);
+   if (err || result != size) {
       debug_printf("Error reading packet from network\n");
-      return result;
+      return err;
    }
    *packet_size = size;
    debug_printf("Received packet from network\n");   

--- a/src/cobo/handshake.h
+++ b/src/cobo/handshake.h
@@ -52,11 +52,11 @@ typedef struct {
       } munge;
       struct {
          char *key_filepath;
-         int key_length_bytes;
+         size_t key_length_bytes;
       } key_in_file;
       struct {
          unsigned char *key;
-         int key_length_bytes;
+         size_t key_length_bytes;
       } explicit_key;
    } data;
 } handshake_protocol_t;

--- a/src/fe/comlib/cobo_fe_comm.c
+++ b/src/fe/comlib/cobo_fe_comm.c
@@ -54,10 +54,11 @@ static int read_msg(int fd, ldcs_message_t *msg)
 int ldcs_audit_server_fe_md_open ( char **hostlist, int numhosts, unsigned int port, unsigned int num_ports,
                                    unique_id_t unique_id, 
                                    void **data  ) {
+   data=data;
    int rc=0;
    int *portlist;
    int root_fd, ack;
-   int i;
+   unsigned int i;
 
    assert(num_ports >= 1);
    portlist = malloc(sizeof(int) * (num_ports+1));
@@ -168,6 +169,7 @@ int ldcs_audit_server_fe_md_waitfor_alive(int timeout_seconds)
 
 int ldcs_audit_server_fe_md_close ( void *data  ) {
   
+   data=data;
    ldcs_message_t out_msg;
    int root_fd;
 
@@ -183,6 +185,7 @@ int ldcs_audit_server_fe_md_close ( void *data  ) {
 
 int ldcs_audit_server_fe_broadcast(ldcs_message_t *msg, void *data)
 {
+   data=data;
    int root_fd;
 
    debug_printf("Broadcasting message to daemons\n");

--- a/src/fe/openmpi_intercept/ompi_intercept.c
+++ b/src/fe/openmpi_intercept/ompi_intercept.c
@@ -40,6 +40,9 @@ static volatile int doing_read = 0;
 
 void on_sigsegv(int sig, siginfo_t *info, void *ctx)
 {
+   sig=sig;
+   info=info;
+   ctx=ctx;
    if (!doing_read)
       return;
    siglongjmp(env, -1);
@@ -69,6 +72,7 @@ static int check_proctable_entry(MPIR_PROCDESC *e)
 
 static void *monitor_main(void *arg)
 {
+   arg=arg;
    struct sigaction act, oact;
    int i, ready = 0;
 

--- a/src/fe/startup/config_mgr.cc
+++ b/src/fe/startup/config_mgr.cc
@@ -808,6 +808,7 @@ bool ConfigMap::toSpindleArgs(spindle_args_t &args, bool alloc_strs) const
                setopt(args.opts, OPT_STOPRELOC, false);
                setopt(args.opts, OPT_OFF, true);
             }
+            break;
          case confPushpull:
             if (strresult == "pull") {
                setopt(args.opts, OPT_PULL, true);

--- a/src/fe/startup/launch_flux.cc
+++ b/src/fe/startup/launch_flux.cc
@@ -157,7 +157,7 @@ bool FluxLauncher::spawnDaemon()
    return true;
 }
 
-bool FluxLauncher::spawnJob(app_id_t id, int app_argc, char **app_argv)
+bool FluxLauncher::spawnJob(app_id_t /*id*/, int /*app_argc*/, char ** /*app_argv*/)
 {
    //Unsed for flux session launcher. Rather than launch jobs under spindle, we will
    // put spindle launch information in the flux KVS, then let the flux run spindle

--- a/src/fe/startup/launch_lsf.cc
+++ b/src/fe/startup/launch_lsf.cc
@@ -95,6 +95,7 @@ const char *LSFLauncher::getNextLSBHost(const char *prev)
 
 void LSFLauncher::countHost(const char *host, void *data, int)
 {
+   host=host;
    int *count = (int *) data;
    (*count)++;
 }
@@ -156,6 +157,7 @@ bool LSFLauncher::spawnDaemon()
 
 bool LSFLauncher::spawnJob(app_id_t id, int app_argc, char **app_argv)
 {
+   app_argc=app_argc;
    debug_printf("Spindle launching LSF job with app-id %lu: %s\n", id, app_argv[0]);
    int pid = fork();
    if (pid == -1) {

--- a/src/fe/startup/launch_slurm.cc
+++ b/src/fe/startup/launch_slurm.cc
@@ -195,6 +195,7 @@ bool SlurmLauncher::spawnDaemon()
 
 bool SlurmLauncher::spawnJob(app_id_t id, int app_argc, char **app_argv)
 {
+   app_argc=app_argc;
    debug_printf("Spindle launching slurm job with app-id %lu: %s\n", id, app_argv[0]);
    int pid = fork();
    if (pid == -1) {

--- a/src/fe/startup/launcher.cc
+++ b/src/fe/startup/launcher.cc
@@ -82,7 +82,7 @@ void Launcher::getSecondaryDaemonArgs(vector<const char *> &)
 {
 }
 
-bool Launcher::setupJob(app_id_t id, int &app_argc, char** &app_argv)
+bool Launcher::setupJob(app_id_t /*id*/, int &app_argc, char** &app_argv)
 {
    int mod_argc;
    char **mod_argv;
@@ -277,17 +277,17 @@ const char *PassthroughLauncher::getDaemonArg()
    return "";
 }
 
-void PassthroughLauncher::getSecondaryDaemonArgs(std::vector<const char *> &secondary_args)
+void PassthroughLauncher::getSecondaryDaemonArgs(std::vector<const char *> & /*secondary_args*/)
 {
    return;
 }
 
-bool PassthroughLauncher::setupJob(app_id_t id, int &app_argc, char** &app_argv)
+bool PassthroughLauncher::setupJob(app_id_t /*id*/, int &/*app_argc*/, char** & /*app_argv*/)
 {
    return true;
 }
 
-bool PassthroughLauncher::spawnJob(app_id_t id, int app_argc, char **app_argv)
+bool PassthroughLauncher::spawnJob(app_id_t id, int /*app_argc*/, char **app_argv)
 {
    debug_printf("Launching job with app-id %lu: %s\n", id, app_argv[0]);
    int pid = fork();

--- a/src/fe/startup/parse_launcher_args.cc
+++ b/src/fe/startup/parse_launcher_args.cc
@@ -444,7 +444,7 @@ bool LauncherParser::parseCustomArg(int /*argc*/, char** /*argv*/, int /*arg_pos
 /**
  * Return false if a launcher argument should be stripped from the command line.
  **/
-bool LauncherParser::includeArg(int argc, char **argv, int pos)
+bool LauncherParser::includeArg(int /*argc*/, char **argv, int pos)
 {
    if (argv[pos][0] == '\0')
       return false;
@@ -668,7 +668,7 @@ bool SerialParser::usesLauncher() const
    return false;
 }
 
-bool SerialParser::isExecutable(int argc, char **argv, int pos, const set<string> &exedirs) const
+bool SerialParser::isExecutable(int /*argc*/, char ** /*argv*/, int pos, const set<string> & /*exedirs*/) const
 {
    return (pos == 0);
 }
@@ -682,7 +682,7 @@ OpenMPIParser::~OpenMPIParser()
 {
 }
 
-bool OpenMPIParser::parseCustomArg(int argc, char **argv, int arg_pos, int &inc_argc) const
+bool OpenMPIParser::parseCustomArg(int /*argc*/, char **argv, int arg_pos, int & /*inc_argc*/) const
 {
    fprintf(stderr, "%s under OpenMPI is not yet supported by Spindle\n", argv[arg_pos]);
    exit(-1);
@@ -697,7 +697,7 @@ JSRunParser::~JSRunParser()
 {
 }
 
-bool JSRunParser::parseCustomArg(int argc, char **argv, int arg_pos, int &inc_argc) const
+bool JSRunParser::parseCustomArg(int /*argc*/, char **argv, int arg_pos, int & /*inc_argc*/) const
 {
    if (strcmp(argv[arg_pos], "--use_spindle") == 0 || (strcmp(argv[arg_pos], "-L") == 0)) {
       fprintf(stderr, "Error: Do not mix spindle job launch wrapper with the jsrun spindle option %s. "
@@ -718,7 +718,7 @@ LRunParser::~LRunParser()
 {
 }
 
-bool LRunParser::parseCustomArg(int argc, char **argv, int arg_pos, int &inc_argc) const
+bool LRunParser::parseCustomArg(int /*argc*/, char **argv, int arg_pos, int & /*inc_argc*/) const
 {
    if (strcmp(argv[arg_pos], "--use_spindle") == 0 || (strcmp(argv[arg_pos], "-L") == 0)) {
       fprintf(stderr, "Error: Do not mix spindle job launch wrapper with the lrun spindle option %s. "
@@ -767,7 +767,7 @@ cmdoption_t *MarkerParser::getArg(int argc, char **argv, int pos) const
    return NULL;
 }
 
-bool MarkerParser::isExecutable(int argc, char **argv, int pos, const std::set<std::string> &exedirs) const
+bool MarkerParser::isExecutable(int /*argc*/, char **argv, int pos, const std::set<std::string> & /*exedirs*/) const
 {
    return (pos > 0 && strcmp(argv[pos-1], "spindlemarker") == 0);
 }

--- a/src/flux/flux-spindle.c
+++ b/src/flux/flux-spindle.c
@@ -124,7 +124,7 @@ static int spindle_in_session_mode(flux_t *flux_handle, int *argc, char ***argv)
    return 1;
 }
 
-static void free_bootstrap_args(int argc, char **argv)
+static void free_bootstrap_args(char **argv)
 {
    int i;
    for (i = 0; argv[i] != NULL; i++)
@@ -242,6 +242,7 @@ static void spindle_ctx_destroy (struct spindle_ctx *ctx)
 
 static void onTermSignal(int sig)
 {
+   sig=sig;
    //Force an exit in the child.
    spindleForceExitBE(SPINDLE_EXIT_TYPE_SOFT);
    alarm(5); //Force shutdown in 5 seconds if not otherwise down
@@ -249,6 +250,7 @@ static void onTermSignal(int sig)
 
 static void onAlarm(int sig)
 {
+   sig=sig;
    spindleForceExitBE(SPINDLE_EXIT_TYPE_HARD);
    _exit(-1);
 }
@@ -514,6 +516,9 @@ static int sp_init (flux_plugin_t *p,
                     flux_plugin_arg_t *arg,
                     void *data)
 {
+    topic=topic;
+    arg=arg;
+    data=data;
     struct spindle_ctx *ctx;
     flux_shell_t *shell = flux_plugin_get_shell (p);
     flux_t *h = flux_shell_get_flux (shell);
@@ -666,6 +671,9 @@ static int sp_task (flux_plugin_t *p,
                     flux_plugin_arg_t *arg,
                     void *data)
 {
+    topic=topic;
+    arg=arg;
+    data=data;
     int session_mode;
     int bootstrap_argc;
     char **bootstrap_argv;
@@ -709,7 +717,7 @@ static int sp_task (flux_plugin_t *p,
     free (s);
 
     if (session_mode)
-       free_bootstrap_args(bootstrap_argc, bootstrap_argv);
+       free_bootstrap_args(bootstrap_argv);
     
     return 0;
 }
@@ -722,7 +730,10 @@ static int sp_exit (flux_plugin_t *p,
                     flux_plugin_arg_t *arg,
                     void *data)
 {
-   flux_shell_t *shell = flux_plugin_get_shell (p);
+    topic=topic;
+    arg=arg;
+    data=data;
+    flux_shell_t *shell = flux_plugin_get_shell (p);
     flux_t *h = flux_shell_get_flux (shell);
     
     debug_printf(1, "In flux plugin sp_exit\n");

--- a/src/flux/fluxmgr.c
+++ b/src/flux/fluxmgr.c
@@ -227,6 +227,7 @@ int fluxmgr_get_from_kvs(char **daemon_args, int timeout_seconds)
 
 int fluxmgr_get_bootstrap(flux_t *fhandle, char **bootstrap_args)
 {
+   fhandle=fhandle;
    int result;
    result = get_from_kvs(NULL, "bootstrap_args", bootstrap_args, 0);
    if (result == GET_FROM_KVS_ERR || result == GET_FROM_KVS_TIMEOUT)

--- a/src/flux/spindlebemgr.c
+++ b/src/flux/spindlebemgr.c
@@ -29,6 +29,7 @@ static int decode_daemon_args(char *daemon_arg_str, unsigned int *port, unsigned
 
 static int post_setup(spindle_args_t *params)
 {
+   params=params;
    ping_readymsg(0);
    clean_readymsg();
    return 0;
@@ -36,6 +37,8 @@ static int post_setup(spindle_args_t *params)
 
 int run_be(int argc, char **argv)
 {
+   argc=argc;
+   argv=argv;
    int result;
    char *daemon_arg_str;
    unsigned int port, num_ports;

--- a/src/include/ldcs_api.h
+++ b/src/include/ldcs_api.h
@@ -112,7 +112,7 @@ typedef  enum {
 struct ldcs_message_header_struct
 {
   ldcs_message_ids_t type;
-  int len;
+  size_t len;
 };
 
 typedef struct ldcs_message_header_struct ldcs_message_header_t;

--- a/src/include/ldcs_api_pipe.h
+++ b/src/include/ldcs_api_pipe.h
@@ -35,8 +35,8 @@ char *ldcs_get_connection_string_pipe(int fd);
 int ldcs_register_connection_pipe(char *connection_str);
 
 /* internal */
-int _ldcs_write_pipe(int fd, const void *data, int bytes );
-int _ldcs_read_pipe(int fd, void *data, int bytes, ldcs_read_block_t block );
+size_t _ldcs_write_pipe(int fd, const void *data, size_t bytes, int *err );
+size_t _ldcs_read_pipe(int fd, void *data, size_t bytes, ldcs_read_block_t block, int *err );
 
 typedef enum {
    LDCS_PIPE_FD_TYPE_SERVER,

--- a/src/logging/spindle_logd.cc
+++ b/src/logging/spindle_logd.cc
@@ -183,6 +183,7 @@ public:
 
    virtual void writeMessage(int proc, const char *msg1, int msg1_size, const char *msg2, int msg2_size)
    {
+      proc=proc;
       if (isExitCode(msg1, msg1_size, msg2, msg2_size)) {
          /* We've received the exitcode */
          shouldExit = true;
@@ -679,6 +680,7 @@ void cleanFiles()
 
 void on_sig(int sig)
 {
+   sig=sig;
    clean();
    exit(0);
 }

--- a/src/server/auditserver/cleanup_proc.cc
+++ b/src/server/auditserver/cleanup_proc.cc
@@ -42,6 +42,7 @@ static bool hit_sigterm = false;
 
 static void on_sigterm(int sig)
 {
+   sig=sig;
    hit_sigterm = true;   
 }
 

--- a/src/server/auditserver/force_exit.c
+++ b/src/server/auditserver/force_exit.c
@@ -102,6 +102,7 @@ int getForceExitFd()
 extern int set_exit_on_client_close(ldcs_process_data_t *procdata);
 int forceExitCB(int fd, int serverid, void *data)
 {
+   serverid=serverid;
    char c;
    int result;
    ldcs_process_data_t *procdata = (ldcs_process_data_t *) data;

--- a/src/server/auditserver/ldcs_audit_server_filemngt.c
+++ b/src/server/auditserver/ldcs_audit_server_filemngt.c
@@ -190,7 +190,7 @@ int filemngt_read_file(char *filename, void *buffer, size_t *size, int strip,
 int filemngt_encode_packet(char *filename, void *filecontents, size_t filesize, int stripped,
                            char **buffer, size_t *buffer_size)
 {
-   int cur_pos = 0;
+   size_t cur_pos = 0;
    int filename_len = strlen(filename) + 1;
    int is_elf = filemngt_is_elf_file(filecontents, filesize);
    //TODO: Remove filesize from allocation if we're doing a non-contig send. Wastes memory.

--- a/src/server/auditserver/ldcs_audit_server_handlers.c
+++ b/src/server/auditserver/ldcs_audit_server_handlers.c
@@ -240,7 +240,7 @@ static int handle_client_dirlists_req(ldcs_process_data_t *procdata, int nc)
    int connid;
    ldcs_client_t *client;
    char *buffer;
-   int len, local_len, ee_len;
+   size_t len, local_len, ee_len;
 
    assert(nc != -1);
    client = procdata->client_table + nc;
@@ -278,6 +278,7 @@ static int handle_client_dirlists_req(ldcs_process_data_t *procdata, int nc)
  **/
 static int handle_client_myrankinfo_msg(ldcs_process_data_t *procdata, int nc, ldcs_message_t *msg)
 {
+   msg=msg;
    int tmpdata[4];
    ldcs_message_t out_msg;
    int connid;
@@ -890,6 +891,7 @@ static int handle_finish_buffer_setup(ldcs_process_data_t *procdata, char *local
  **/
 static int handle_setup_alias(ldcs_process_data_t *procdata, char *pathname, char *alias_to)
 {
+   procdata=procdata;
    char filename[MAX_PATH_LEN+1], dirname[MAX_PATH_LEN+1];
    char *localname;
    int errcode;
@@ -1071,7 +1073,7 @@ static int handle_broadcast_errorcode(ldcs_process_data_t *procdata, char *pathn
    size_t packet_size = 0;
    int result;
    int pathname_len = strlen(pathname)+1;
-   int pos = 0;
+   size_t pos = 0;
    ldcs_message_t msg;
    double starttime;
    
@@ -1440,6 +1442,7 @@ static int handle_request_file(ldcs_process_data_t *procdata, node_peer_t from, 
       case REQ_DIRECTORY:
          dir_result = handle_send_query(procdata, dirname, 1, 0);
          add_requestor(procdata->file_requests, dirname, from);
+         [[ fallthrough ]]; /* Requires gcc >= 10.0 or -std=c23 or ... */
          /* Fall through to next case and request file */
       case REQ_FILE:
          result = handle_send_query(procdata, pathname, 0, is_dso);
@@ -1531,8 +1534,11 @@ static int handle_send_file_query(ldcs_process_data_t *procdata, char *fullpath,
  **/
 static int handle_file_errcode(ldcs_process_data_t *procdata, ldcs_message_t *msg, node_peer_t peer, broadcast_t bcast)
 {
+   peer=peer;
+   bcast=bcast;
    char *pathname;
-   int errcode, pathname_len, result, pos = 0;
+   int errcode, result;
+   size_t pathname_len, pos = 0;
    unsigned char *data;
 
    data = (unsigned char *) msg->data;
@@ -1665,6 +1671,7 @@ static int handle_directory_recv(ldcs_process_data_t *procdata, ldcs_message_t *
  **/
 static int handle_alias_recv(ldcs_process_data_t *procdata, ldcs_message_t *msg, broadcast_t bcast)
 {
+   bcast=bcast;
    char *alias_from, *alias_to;
    char *data;
    size_t from_size;
@@ -1992,6 +1999,7 @@ int handle_server_message(ldcs_process_data_t *procdata, node_peer_t peer, ldcs_
  **/
 int handle_client_start(ldcs_process_data_t *procdata, int nc)
 {
+   nc=nc;
    if (procdata->sent_exit_ready) {
       return handle_send_exit_cancel(procdata);
    }
@@ -2023,8 +2031,8 @@ int handle_client_end(ldcs_process_data_t *procdata, int nc)
 
 static int handle_preload_filelist(ldcs_process_data_t *procdata, ldcs_message_t *msg)
 {
-   int cur = 0, global_result = 0, result;
-   int num_dirs, num_files, i;
+   size_t cur = 0;
+   int num_dirs, num_files, i, global_result = 0, result;
    char *data = (char *) msg->data;
    char *pathname;
    
@@ -2498,12 +2506,11 @@ static int handle_cache_ldso(ldcs_process_data_t *procdata, char *pathname, int 
 static int handle_broadcast_metadata(ldcs_process_data_t *procdata, char *pathname, int file_exists, unsigned char *buf, size_t buf_size, metadata_t mdtype)
 {
    char *packet_buffer = NULL;
-   size_t packet_size;
+   size_t packet_size, pos = 0;
    double starttime;
    int result;
    ldcs_message_t msg;
    int pathname_len = strlen(pathname) + 1;
-   int pos = 0;
    extended_stat_t *sbuf = (extended_stat_t *) buf;
    const char *mount;
    int mount_len;
@@ -2582,11 +2589,12 @@ static int handle_broadcast_metadata(ldcs_process_data_t *procdata, char *pathna
  **/
 static int handle_metadata_recv(ldcs_process_data_t *procdata, ldcs_message_t *msg, metadata_t mdtype, node_peer_t peer)
 {
-   int file_exists;
+   peer=peer;
+   int file_exists, result;
    char pathname[MAX_PATH_LEN+1], *localpath;
    extended_stat_t buf;
    ldso_info_t ldsoinfo;
-   int pos = 0, pathlen, result, payload_size = 0, mount_len = 0, bytes_left;
+   size_t pos = 0, pathlen, payload_size = 0, mount_len = 0, bytes_left;
    char *buffer = (char *) msg->data;
    unsigned char *payload = NULL;
    char mount[MAX_PATH_LEN+1];
@@ -2596,13 +2604,13 @@ static int handle_metadata_recv(ldcs_process_data_t *procdata, ldcs_message_t *m
    memcpy(&file_exists, buffer + pos, sizeof(int));
    pos += sizeof(int);
 
-   memcpy(&pathlen, buffer + pos, sizeof(int));
+   memcpy(&pathlen, buffer + pos, sizeof(size_t));
    pos += sizeof(int);
-   assert(pathlen >= 0 && pathlen <= MAX_PATH_LEN);
+   assert(pathlen <= MAX_PATH_LEN);
 
-   memcpy(&mount_len, buffer + pos, sizeof(int));
+   memcpy(&mount_len, buffer + pos, sizeof(size_t));
    pos += sizeof(int);
-   assert(mount_len >= 0 && mount_len <= MAX_PATH_LEN);
+   assert(mount_len <= MAX_PATH_LEN);
    
    memcpy(pathname, buffer + pos, pathlen);
    pos += pathlen;
@@ -3063,6 +3071,7 @@ static int handle_send_exit_ready_if_done(ldcs_process_data_t *procdata)
  **/
 static int handle_exit_ready_msg(ldcs_process_data_t *procdata, ldcs_message_t *msg)
 {
+   msg=msg;
    debug_printf2("Got exit ready message\n");
    procdata->exit_readys_recvd++;
    return handle_send_exit_ready_if_done(procdata);
@@ -3075,6 +3084,7 @@ static int handle_exit_ready_msg(ldcs_process_data_t *procdata, ldcs_message_t *
  **/
 static int handle_exit_cancel_msg(ldcs_process_data_t *procdata, ldcs_message_t *msg)
 {
+   msg=msg;
    debug_printf2("Got exit cancel\n");
    assert(procdata->exit_readys_recvd > 0);
    procdata->exit_readys_recvd--;
@@ -3128,6 +3138,7 @@ static int handle_close_client_query(ldcs_process_data_t *procdata, int nc)
  **/
 int exit_note_cb(int fd, int serverid, void *data)
 {
+   serverid=serverid;
    int result;
    ldcs_process_data_t *procdata = (ldcs_process_data_t *) data;
    int eresult = 0;

--- a/src/server/auditserver/ldcs_audit_server_md_cobo.c
+++ b/src/server/auditserver/ldcs_audit_server_md_cobo.c
@@ -83,7 +83,7 @@ int ldcs_audit_server_md_init(unsigned int port, unsigned int num_ports,
    int rc=0;
    unsigned int *portlist;
    int my_rank, ranks, fanout;
-   int i;
+   unsigned int i;
 
    portlist = malloc(sizeof(unsigned int) * (num_ports + 1));
    for (i = 0; i < num_ports; i++) {
@@ -169,6 +169,7 @@ int ldcs_audit_server_md_unregister_fd ( ldcs_process_data_t *ldcs_process_data 
 
 int ldcs_audit_server_md_destroy ( ldcs_process_data_t *ldcs_process_data ) 
 {
+   ldcs_process_data=ldcs_process_data;
    /* Nothing to be done.  Sockets will be closed when we exit. */
    if (cobo_close() != COBO_SUCCESS) {
       debug_printf3("Failed to close\n");
@@ -283,6 +284,7 @@ int ldcs_audit_server_md_is_parent(node_peer_t peer)
 
 int ldcs_audit_server_md_cobo_CB(int fd, int nc, void *data)
 {
+   nc=nc;
    int rc=0;
    ldcs_process_data_t *ldcs_process_data = ( ldcs_process_data_t *) data ;
    ldcs_message_t msg;
@@ -310,6 +312,7 @@ int ldcs_audit_server_md_cobo_CB(int fd, int nc, void *data)
 
 int ldcs_audit_server_md_send(ldcs_process_data_t *ldcs_process_data, ldcs_message_t *msg, node_peer_t peer)
 {
+   ldcs_process_data=ldcs_process_data;
    int fd = (int) (long) peer;
    return write_msg(fd, msg);
 }
@@ -352,6 +355,7 @@ int ldcs_audit_server_md_send_noncontig(ldcs_process_data_t *ldcs_process_data, 
 
 int ldcs_audit_server_md_broadcast(ldcs_process_data_t *ldcs_process_data, ldcs_message_t *msg)
 {
+   ldcs_process_data=ldcs_process_data;
    int fd, i;
    int result, global_result = 0;
    int num_childs = 0;
@@ -393,6 +397,7 @@ int ldcs_audit_server_md_broadcast_noncontig(ldcs_process_data_t *ldcs_process_d
 
 int ldcs_audit_server_md_get_num_children(ldcs_process_data_t *procdata)
 {
+   procdata=procdata;
    int num_childs = 0;
    cobo_get_num_childs(&num_childs);
    return num_childs;

--- a/src/server/auditserver/ldcs_audit_server_numa.c
+++ b/src/server/auditserver/ldcs_audit_server_numa.c
@@ -51,7 +51,7 @@ static int initialize_numa_lib() {
    char buffer[MAX_PATH_LEN+1];                    \
    char *end;                                      \
    char *start = colon_seperated_list;             \
-   int str_len;                                    \
+   size_t str_len;                                 \
    while (*start != '\0') {                        \
      while (*start == ':') {                       \
        start++;                                    \
@@ -77,7 +77,7 @@ static int initialize_numa_lib() {
    start = end;                                 \
    } 
 
-static int pattern_match(char *pattern, char *filename, int filename_len) {
+static int pattern_match(char *pattern, char *filename, size_t filename_len) {
    int should_match_at_start = 0, should_match_at_end = 0;
    size_t pattern_len = strlen(pattern);
    if (pattern[0] == '^') {

--- a/src/server/auditserver/ldcs_audit_server_process.c
+++ b/src/server/auditserver/ldcs_audit_server_process.c
@@ -47,6 +47,7 @@ ldcs_process_data_t ldcs_process_data;
 unsigned int opts;
 
 int _listen_exit_loop_cb_func ( int num_fds,  void * data) {
+  num_fds=num_fds;
   int rc=0;
   ldcs_process_data_t *ldcs_process_data = ( ldcs_process_data_t *) data ;
 

--- a/src/server/auditserver/ldcs_audit_server_process.h
+++ b/src/server/auditserver/ldcs_audit_server_process.h
@@ -106,7 +106,7 @@ typedef struct ldcs_client_struct ldcs_client_t;
 
 typedef struct msgbundle_entry_t {
    unsigned char *cache;
-   int position;
+   size_t position;
    void* node;
    struct msgbundle_entry_t *next;
    char name[16];
@@ -133,7 +133,7 @@ struct ldcs_process_data_struct
   char *numa_substrs;
   char *numa_excludes;   
   msgbundle_entry_t *msgbundle_entries;
-  int msgbundle_cache_size_kb;
+  size_t msgbundle_cache_size_kb;
   int msgbundle_timeout_ms;
   int handling_bundle;
   number_t number;

--- a/src/server/auditserver/ldcs_audit_server_requestors.c
+++ b/src/server/auditserver/ldcs_audit_server_requestors.c
@@ -21,7 +21,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 struct requested_file_struct
 {
    char *path;
-   int hash_val;
+   unsigned int hash_val;
    int requestors_num;
    int requestors_size;
    node_peer_t *requestors;

--- a/src/server/auditserver/ldcs_audit_server_server_cb.c
+++ b/src/server/auditserver/ldcs_audit_server_server_cb.c
@@ -27,6 +27,7 @@
 #include "ldcs_audit_server_handlers.h"
 
 int _ldcs_server_CB ( int infd, int serverid, void *data ) {
+   infd=infd;
    int rc=0;
    ldcs_process_data_t *ldcs_process_data = (ldcs_process_data_t *) data ;
    int nc, fd, more_avail;

--- a/src/server/auditserver/ldcs_elf_read.c
+++ b/src/server/auditserver/ldcs_elf_read.c
@@ -32,10 +32,9 @@ static int readUpTo(FILE *f, unsigned char *buffer, size_t *cur_pos, size_t new_
       return 0;
 
    do {
+      errno = 0;
       result = fread(buffer + *cur_pos, 1, new_size - *cur_pos, f);
-   } while (result == -1 && errno == EINTR);
-   if (result == -1)
-      return -1;
+   } while (errno == EINTR);
    *cur_pos += result;
    return 0;
 }

--- a/src/server/auditserver/msgbundle.c
+++ b/src/server/auditserver/msgbundle.c
@@ -38,7 +38,7 @@ void msgbundle_init(ldcs_process_data_t *procdata)
    assert(procdata->msgbundle_cache_size_kb);
    assert(procdata->msgbundle_timeout_ms);
    procdata->msgbundle_entries = NULL;
-   debug_printf("Initializing message bundling with buffer of size %u kb and "
+   debug_printf("Initializing message bundling with buffer of size %zu kb and "
                 "send timeout of %u ms\n", procdata->msgbundle_cache_size_kb,
                 procdata->msgbundle_timeout_ms);
 
@@ -54,6 +54,7 @@ void msgbundle_init(ldcs_process_data_t *procdata)
 
 void msgbundle_done(ldcs_process_data_t *procdata)
 {   
+   procdata=procdata;
    void *retval;
    if (!initialized)
       return;
@@ -173,6 +174,7 @@ static int flush_msgbuffer(msgbundle_entry_t *mb, ldcs_process_data_t *procdata)
 
 static int flush_msgbuffer_cb(int fd, int serverid, void *data)
 {
+   serverid=serverid;
    msgbundle_entry_t *mb;
    ldcs_process_data_t *procdata = (ldcs_process_data_t *) data;
    char throwaway_byte;
@@ -201,6 +203,8 @@ void msgbundle_force_flush(ldcs_process_data_t *procdata)
 
 static void start_cache_timeout(int timeout_ms, ldcs_process_data_t *procdata)
 {
+   timeout_ms=timeout_ms;
+   procdata=procdata;
    pthread_mutex_lock(&mut);
 
    if (!active_timeout) {
@@ -224,8 +228,8 @@ int spindle_send_worker(ldcs_process_data_t *procdata, ldcs_message_t *msg, node
       return 0;
    }
    
-   debug_printf2("Processing message of size header:%lu + body:%lu (secondary:%lu) = %lu for message bundling\n",
-                 sizeof(ldcs_message_header_t), (unsigned long) msg->header.len, secondary_size,
+   debug_printf2("Processing message of size header:%zu + body:%zu (secondary:%zu) = %zu for message bundling\n",
+                 sizeof(ldcs_message_header_t), msg->header.len, secondary_size,
                  sizeof(ldcs_message_header_t) + msg->header.len);
 
    for (mb = procdata->msgbundle_entries; mb && mb->node != node; mb = mb->next);
@@ -233,8 +237,8 @@ int spindle_send_worker(ldcs_process_data_t *procdata, ldcs_message_t *msg, node
    if (sizeof(msg->header)*2 + msg->header.len >=
        procdata->msgbundle_cache_size_kb*1024)
    {
-      debug_printf2("Not using message bundling because packet size (%ld) is greater than"
-                    "cache size %d.\n",
+      debug_printf2("Not using message bundling because packet size (%zu) is greater than"
+                    "cache size %zu.\n",
                     sizeof(msg->header)*2 + msg->header.len,
                     procdata->msgbundle_cache_size_kb*1024);
       if (mb)
@@ -269,7 +273,7 @@ int spindle_send_worker(ldcs_process_data_t *procdata, ldcs_message_t *msg, node
        procdata->msgbundle_cache_size_kb*1024)
    {
       debug_printf2("Flushing message buffer due to no space for adding new message."
-                    "Current size = %u, new message size = %lu, capacity = %u\n",
+                    "Current size = %zu, new message size = %zu, capacity = %zu\n",
                     mb->position,
                     sizeof(msg->header) + msg->header.len,
                     procdata->msgbundle_cache_size_kb*1024);
@@ -280,7 +284,7 @@ int spindle_send_worker(ldcs_process_data_t *procdata, ldcs_message_t *msg, node
       debug_printf2("Starting new message buffer\n");
    }
    else {
-      debug_printf2("Appending message at position %d\n", mb->position);
+      debug_printf2("Appending message at position %zu\n", mb->position);
    }
 
    memcpy(mb->cache + mb->position, &msg->header, sizeof(ldcs_message_header_t));
@@ -291,8 +295,8 @@ int spindle_send_worker(ldcs_process_data_t *procdata, ldcs_message_t *msg, node
       memcpy(mb->cache + mb->position, secondary_data, secondary_size);
       mb->position += secondary_size;
    }
-   debug_printf2("Cached data in message buffer to node %s, which is %u of %u bytes full.\n",
-                 mb->name, (int) mb->position, procdata->msgbundle_cache_size_kb*1024);
+   debug_printf2("Cached data in message buffer to node %s, which is %zu of %zu bytes full.\n",
+                 mb->name, mb->position, procdata->msgbundle_cache_size_kb*1024);
 
    start_cache_timeout(procdata->msgbundle_timeout_ms, procdata);
    return 0;

--- a/src/server/cache/global_name.c
+++ b/src/server/cache/global_name.c
@@ -63,8 +63,8 @@ void grow_global_name_list()
 static int get_global_file_index(char* file)
 {
   char buf[MAX_PATH_LEN+1];
-  int len = strlen(file);
-  int cnt;
+  size_t len = strlen(file);
+  size_t cnt;
   int rval;
   int val;
 

--- a/src/server/comlib/ldcs_api_biter.c
+++ b/src/server/comlib/ldcs_api_biter.c
@@ -67,6 +67,7 @@ int ldcs_create_server_biter(char* location, number_t num)
 
 int ldcs_open_server_connection_biter(int id)
 {
+   id=id;
    assert(0 && "Unused");
    return -1;
 }
@@ -167,7 +168,7 @@ int ldcs_send_msg_biter(int fd, ldcs_message_t *msg)
    
    if (spindle_debug_prints) {
       int rank = biterd_get_rank(session, proc);
-      debug_printf3("Sending message of size %d to rank %d (session = %d, proc = %d)\n",
+      debug_printf3("Sending message of size %zu to rank %d (session = %d, proc = %d)\n",
                     msg->header.len, rank, session, proc);
    }
    
@@ -183,7 +184,7 @@ int ldcs_send_msg_biter(int fd, ldcs_message_t *msg)
 
    result = biterd_write(session, proc, msg->data, msg->header.len);
    if (result == -1) {
-      err_printf("Error writing message of size %d to session %d, proc %d: %s\n",
+      err_printf("Error writing message of size %zu to session %d, proc %d: %s\n",
                  msg->header.len, session, proc, biterd_lasterror_str());
       return -1;
    }
@@ -246,6 +247,7 @@ int ldcs_socket_id_to_nc_biter(int id, int fd, ldcs_process_data_t *process_data
 
 int ldcs_recv_msg_static_biter(int connid, ldcs_message_t *msg, ldcs_read_block_t block)
 {
+   block=block;
    int session = CLIENT_ID_SESSION(connid);
    int proc = CLIENT_ID_PROC(connid);
    int result;
@@ -271,7 +273,7 @@ int ldcs_recv_msg_static_biter(int connid, ldcs_message_t *msg, ldcs_read_block_
       return -1;
    }
 
-   debug_printf3("Message to be read is of size %d (session = %d, proc = %d)\n",
+   debug_printf3("Message to be read is of size %zu (session = %d, proc = %d)\n",
                  msg->header.len, session, proc);
    
    if (msg->header.len == 0) {
@@ -281,7 +283,7 @@ int ldcs_recv_msg_static_biter(int connid, ldcs_message_t *msg, ldcs_read_block_
 
    result = biterd_read(session, proc, msg->data, msg->header.len);
    if (result == -1) {
-      err_printf("Error reading message of size %d from session %d, proc %d: %s\n",
+      err_printf("Error reading message of size %zu from session %d, proc %d: %s\n",
                  msg->header.len, session, proc, biterd_lasterror_str());
       return -1;
    }

--- a/src/server/comlib/ldcs_api_pipe.c
+++ b/src/server/comlib/ldcs_api_pipe.c
@@ -85,7 +85,7 @@ void free_fd_pipe (int fd) {
 
 int ldcs_get_fd_pipe (int fd) {
   int realfd=-1;
-  if ((fd<0) || (fd>fdlist_pipe_size) )  _error("wrong fd");
+  if ((fd<0) || (fd>fdlist_pipe_size) )  err_printf("wrong fd");
   if(fdlist_pipe[fd].inuse) {
     if(fdlist_pipe[fd].type==LDCS_PIPE_FD_TYPE_SERVER) {
       realfd=ldcs_notify_get_fd(fdlist_pipe[fd].notify_fd);
@@ -101,6 +101,7 @@ int ldcs_get_fd_pipe (int fd) {
 extern int spindle_mkdir(char *orig_path);
 
 int ldcs_create_server_pipe(char* location, number_t number) {
+  number=number;
   int fd;
 
   fd=get_new_fd_pipe();
@@ -112,7 +113,7 @@ int ldcs_create_server_pipe(char* location, number_t number) {
 
   if (-1 == spindle_mkdir(staging_dir)) {
      printf("mkdir: ERROR during mkdir %s\n", staging_dir);
-     _error("mkdir failed");
+     err_printf("mkdir failed");
   }
 
   char readypath[MAX_PATH_LEN];
@@ -138,16 +139,18 @@ int ldcs_create_server_pipe(char* location, number_t number) {
 
 int ldcs_open_server_connection_pipe(int fd) {
   /*  */
+  fd=fd;
   return(-1);
 }
 
 int ldcs_open_server_connections_pipe(int fd, int nc, int *more_avail) {
+  nc=nc;
   int  fifoid, inout, connfd;
   char fifo[MAX_PATH_LEN];
   char *fifo_file;
   int  pid;
   
-  if ((fd<0) || (fd>fdlist_pipe_size) )  _error("wrong fd");
+  if ((fd<0) || (fd>fdlist_pipe_size) )  err_printf("wrong fd");
   
 
   /* wait until a <pid>-1 fifo is created */
@@ -175,13 +178,13 @@ int ldcs_open_server_connections_pipe(int fd, int nc, int *more_avail) {
   fdlist_pipe[connfd].in_fn = strdup(fifo);
 
   debug_printf3("before open fifo '%s'\n",fdlist_pipe[connfd].out_fn);
-  if (-1 == (fifoid = open(fdlist_pipe[connfd].out_fn, O_WRONLY))) _error("open fifo failed");
+  if (-1 == (fifoid = open(fdlist_pipe[connfd].out_fn, O_WRONLY))) err_printf("open fifo failed");
   debug_printf3("after open fifo (out): -> fifoid=%d\n",fifoid);
   fdlist_pipe[connfd].out_fd=fifoid;
 
   debug_printf3("before open fifo '%s'\n",fdlist_pipe[connfd].in_fn);
-  if (-1 == (fifoid = open(fdlist_pipe[connfd].in_fn, O_RDONLY|O_NONBLOCK)))  _error("open fifo failed");
-  /* if (-1 == (fifoid = open(fdlist_pipe[connfd].in_fn, O_RDONLY)))  _error("open fifo failed"); */
+  if (-1 == (fifoid = open(fdlist_pipe[connfd].in_fn, O_RDONLY|O_NONBLOCK)))  err_printf("open fifo failed");
+  /* if (-1 == (fifoid = open(fdlist_pipe[connfd].in_fn, O_RDONLY)))  err_printf("open fifo failed"); */
   debug_printf3("after open fifo (in) : -> fifoid=%d\n",fifoid);
   fdlist_pipe[connfd].in_fd=fifoid;
 
@@ -205,7 +208,7 @@ int ldcs_close_server_connection_pipe(int fd) {
   int result;
   struct stat st;
 
-  if ((fd<0) || (fd>fdlist_pipe_size) )  _error("wrong fd");
+  if ((fd<0) || (fd>fdlist_pipe_size) )  err_printf("wrong fd");
   
   debug_printf3(" closing fd %d for conn %d, closing connection\n",fdlist_pipe[fd].in_fd,fd);
   close(fdlist_pipe[fd].in_fd);
@@ -253,7 +256,7 @@ int ldcs_destroy_server_pipe(int fd) {
   int rc=0;
   char path[MAX_PATH_LEN];
 
-  if ((fd<0) || (fd>fdlist_pipe_size) )  _error("wrong fd");
+  if ((fd<0) || (fd>fdlist_pipe_size) )  err_printf("wrong fd");
   
   ldcs_notify_destroy(fdlist_pipe[fd].notify_fd);
 
@@ -270,21 +273,22 @@ int ldcs_destroy_server_pipe(int fd) {
 /* ************************************************************** */
 int ldcs_send_msg_pipe(int fd, ldcs_message_t * msg) {
 
-  int n;
+  size_t n;
+  int err;
 
-  if ((fd<0) || (fd>fdlist_pipe_size) )  _error("wrong fd");
+  if ((fd<0) || (fd>fdlist_pipe_size) )  err_printf("wrong fd");
   
-  debug_printf3("sending message of type: %s len=%d data=%s ...\n",
+  debug_printf3("sending message of type: %s len=%zu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,msg->data );  
 
-  n = _ldcs_write_pipe(fdlist_pipe[fd].out_fd,&msg->header,sizeof(msg->header));
-  if (n < 0) _error("ERROR writing header to pipe");
+  n = _ldcs_write_pipe(fdlist_pipe[fd].out_fd, &msg->header, sizeof(msg->header), &err);
+  if (err) err_printf("ERROR writing header to pipe");
 
   if(msg->header.len>0) {
-    n = _ldcs_write_pipe(fdlist_pipe[fd].out_fd,(void *) msg->data,msg->header.len);
-    if (n < 0) _error("ERROR writing data to pipe");
-    if (n != msg->header.len) _error("sent different number of bytes for message data");
+    n = _ldcs_write_pipe(fdlist_pipe[fd].out_fd,(void *) msg->data,msg->header.len, &err);
+    if (err) err_printf("ERROR writing data to pipe");
+    if (n != msg->header.len) err_printf("sent different number of bytes for message data");
   }
     
   return(0);
@@ -292,34 +296,35 @@ int ldcs_send_msg_pipe(int fd, ldcs_message_t * msg) {
 
 ldcs_message_t * ldcs_recv_msg_pipe(int fd, ldcs_read_block_t block ) {
   ldcs_message_t *msg;
-  int n;
+  size_t n;
+  int err;
 
-  if ((fd<0) || (fd>fdlist_pipe_size) )  _error("wrong fd");
+  if ((fd<0) || (fd>fdlist_pipe_size) )  err_printf("wrong fd");
 
   msg = (ldcs_message_t *) malloc(sizeof(ldcs_message_t));
-  if (!msg)  _error("could not allocate memory for message");
+  if (!msg)  err_printf("could not allocate memory for message");
 
-  n = _ldcs_read_pipe(fdlist_pipe[fd].in_fd,&msg->header,sizeof(msg->header), block);
+  n = _ldcs_read_pipe(fdlist_pipe[fd].in_fd,&msg->header,sizeof(msg->header), block, &err);
+  if (err) err_printf("ERROR reading header from connection");
   if (n == 0) {
     free(msg);
     return(NULL);
   }
-  if (n < 0) _error("ERROR reading header from connection");
 
   if(msg->header.len>0) {
 
     msg->data = (char *) malloc(msg->header.len);
-    if (!msg)  _error("could not allocate memory for message data");
+    if (!msg)  err_printf("could not allocate memory for message data");
 
-    n = _ldcs_read_pipe(fdlist_pipe[fd].in_fd,msg->data,msg->header.len, LDCS_READ_BLOCK);
-    if (n < 0) _error("ERROR reading message data from socket");
-    if (n != msg->header.len) _error("received different number of bytes for message data");
+    n = _ldcs_read_pipe(fdlist_pipe[fd].in_fd,msg->data,msg->header.len, LDCS_READ_BLOCK, &err);
+    if (err) err_printf("ERROR reading message data from socket");
+    if (n != msg->header.len) err_printf("received different number of bytes for message data");
 
   } else {
     msg->data = NULL;
   }
 
-  debug_printf3("received message of type: %s len=%d data=%s ...\n",
+  debug_printf3("received message of type: %s len=%zu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len, msg->data );
 
@@ -327,13 +332,15 @@ ldcs_message_t * ldcs_recv_msg_pipe(int fd, ldcs_read_block_t block ) {
 }
 
 int ldcs_recv_msg_static_pipe(int fd, ldcs_message_t *msg, ldcs_read_block_t block) {
-  int n;
+  size_t n;
+  int err;
   int rc=0;
   msg->header.type=LDCS_MSG_UNKNOWN;
   msg->header.len=0;
-  if ((fd<0) || (fd>fdlist_pipe_size) )  _error("wrong fd");
+  if ((fd<0) || (fd>fdlist_pipe_size) )  err_printf("wrong fd");
 
-  n = _ldcs_read_pipe(fdlist_pipe[fd].in_fd,&msg->header,sizeof(msg->header), block);
+  n = _ldcs_read_pipe(fdlist_pipe[fd].in_fd,&msg->header,sizeof(msg->header), block, &err);
+  if (err) err_printf("ERROR reading header from connection");
   if (n == 0) {
      /* Disconnect.  Return an artificial client end message */
      debug_printf2("Client disconnected.  Returning END message\n");
@@ -342,22 +349,19 @@ int ldcs_recv_msg_static_pipe(int fd, ldcs_message_t *msg, ldcs_read_block_t blo
      msg->data = NULL;
      return(rc);
   }
-  if (n < 0) _error("ERROR reading header from connection");
 
   if(msg->header.len>0) {
-    n = _ldcs_read_pipe(fdlist_pipe[fd].in_fd,msg->data,msg->header.len, LDCS_READ_BLOCK);
-    if (n == 0) 
-       return(rc);
-    if (n < 0) {
-       int error = errno;
-       err_printf("Error during read of pipe: %s (%d)\n", strerror(error), error);
+    n = _ldcs_read_pipe(fdlist_pipe[fd].in_fd,msg->data,msg->header.len, LDCS_READ_BLOCK, &err);
+    if (err) {
+       err_printf("Error during read of pipe: %s (%d)\n", strerror(err), err);
        return -1;
     }
+    if (n == 0)
+       return(rc);
     if (n != msg->header.len) {
-       int error = errno;
        err_printf("Partial read on pipe.  Got %u / %u: %s (%d)\n",
                   (unsigned) n, (unsigned) msg->header.len,
-                  strerror(error), error);
+                  strerror(err), err);
        return -1;
     }
 
@@ -365,28 +369,28 @@ int ldcs_recv_msg_static_pipe(int fd, ldcs_message_t *msg, ldcs_read_block_t blo
     *msg->data = '\0';
   }
 
-  debug_printf3("received message of type: %s len=%d data=%s ...\n",
+  debug_printf3("received message of type: %s len=%zu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len, msg->data );
 
   return(rc);
 }
 
-int _ldcs_read_pipe(int fd, void *data, int bytes, ldcs_read_block_t block ) {
+size_t _ldcs_read_pipe(int fd, void *data, size_t bytes, ldcs_read_block_t block, int *err ) {
 
-  int         left,bsumread;
-  ssize_t     btoread, bread;
-  char       *dataptr;
+  ssize_t    rc;
+  size_t     btoread, bread,left=bytes,bsumread=0;
+  char       *dataptr= (char*) data;
   int print_count = 512;
-  left      = bytes;
-  bsumread  = 0;
-  dataptr   = (char*) data;
 
   while (left > 0)  {
     btoread    = left;
     debug_printf3("before read from fifo %d, bytes_to_read = %ld\n", fd, btoread);
-    bread      = read(fd, dataptr, btoread);
-    if(bread<0) {
+    errno=0;
+    rc = read(fd, dataptr, btoread);
+    *err = errno;
+    bread=(size_t)rc;
+    if(rc<0) {
        if( (errno==EAGAIN) || (errno==EWOULDBLOCK) ) {
           if (print_count-- > 0)
              debug_printf3("read from fifo: got EAGAIN or EWOULDBLOCK\n");
@@ -394,11 +398,11 @@ int _ldcs_read_pipe(int fd, void *data, int bytes, ldcs_read_block_t block ) {
              return 0;
           else
              continue;
-       } else { 
-          debug_printf3("read from fifo: %ld bytes ... errno=%d (%s)\n",bread,errno,strerror(errno));
+       } else {
+          debug_printf3("read from fifo: %zu bytes ... errno=%d (%s)\n",bread,errno,strerror(errno));
        }
     } else {
-       debug_printf3("read from fifo: %ld bytes ...\n",bread);
+       debug_printf3("read from fifo: %zu bytes ...\n",bread);
     }
     if(bread>0) {
       left      -= bread;
@@ -414,9 +418,9 @@ int _ldcs_read_pipe(int fd, void *data, int bytes, ldcs_read_block_t block ) {
 
 
 
-int _ldcs_write_pipe(int fd, const void *data, int bytes ) {
-  int         left,bsumwrote;
-  ssize_t     bwrite, bwrote;
+size_t _ldcs_write_pipe(int fd, const void *data, size_t bytes, int *err ) {
+  ssize_t    rc;
+  size_t     bwrite, bwrote, left, bsumwrote;
   char       *dataptr;
   
   left      = bytes;
@@ -425,7 +429,15 @@ int _ldcs_write_pipe(int fd, const void *data, int bytes ) {
 
   while (left > 0) {
     bwrite     = left;
-    bwrote     = write(fd, dataptr, bwrite);
+    errno      = 0;
+    rc         = write(fd, dataptr, bwrite);
+    *err       = errno;
+    if( -1 == rc ){
+        err_printf("Write to pipe %d failed, errno=%d(%s)\n",
+                fd, *err, strerror(*err) );
+        break;
+    }
+    bwrote     = (size_t)rc;
     left      -= bwrote;
     dataptr   += bwrote;
     bsumwrote += bwrote;
@@ -440,5 +452,7 @@ int ldcs_get_aux_fd_pipe()
 
 int ldcs_socket_id_to_nc_pipe(int id, int fd, ldcs_process_data_t *process_data)
 {
+   fd=fd;
+   process_data=process_data;
    return id;
 }

--- a/src/server/comlib/ldcs_api_socket.c
+++ b/src/server/comlib/ldcs_api_socket.c
@@ -84,6 +84,7 @@ int ldcs_get_fd_socket (int fd) {
 
 
 int ldcs_create_server_socket(char* location, number_t number) {
+  location=location;
   int fd, sockfd;
   struct sockaddr_in serv_addr;
 
@@ -157,6 +158,7 @@ int ldcs_open_server_connection_socket(int fd) {
 };
 
 int ldcs_open_server_connections_socket(int fd, int nc, int *more_avail) {
+  nc=nc;
   *more_avail=0;
   return(ldcs_open_server_connection_socket(fd));
 };
@@ -183,29 +185,32 @@ int ldcs_destroy_server_socket(int fd) {
 /* ************************************************************** */
 /* message transfer functions                                     */
 /* ************************************************************** */
-static int _ldcs_read_socket(int fd, void *data, int bytes, ldcs_read_block_t block) {
+static size_t _ldcs_read_socket(int fd, void *data, size_t bytes, ldcs_read_block_t block, int *err) {
 
-  int         left,bsumread;
-  ssize_t      btoread, bread;
-  char       *dataptr;
-  
-  left      = bytes;
-  bsumread  = 0;
-  dataptr   = (char*) data;
+  size_t    btoread, bread, bsumread=0, left=bytes;
+  char       *dataptr = (char*) data;
+  ssize_t   rc;
 
   while (left > 0)  {
     btoread    = left;
-    bread      = read(fd, dataptr, btoread);
-    if(bread<0) {
+    errno      = 0;
+    rc         = read(fd, dataptr, btoread);
+    *err       = errno;
+    bread      = (size_t)rc;
+    if(rc<0) {
       if( (errno==EAGAIN) || (errno==EWOULDBLOCK) ) {
-	debug_printf3("read from socket: got EAGAIN or EWOULDBLOCK\n");
-	if(block==LDCS_READ_NO_BLOCK) return(0);
-	else continue;
-      } else { 
-         debug_printf3("read from socket: %ld bytes ... errno=%d (%s)\n",bread,errno,strerror(errno));
+	    debug_printf3("read from socket: got EAGAIN or EWOULDBLOCK\n");
+	    if(block==LDCS_READ_NO_BLOCK){
+            return(0);
+        }
+	    else{
+            continue;
+        }
+      } else {
+         debug_printf3("read from socket: errno=%d (%s)\n",errno,strerror(errno));
       }
     } else {
-      debug_printf3("read from socket: %ld bytes ...\n",bread);
+      debug_printf3("read from socket: %zu bytes ...\n",bread);
     }
 
     if(bread>0) {
@@ -247,7 +252,7 @@ int ldcs_send_msg_socket(int fd, ldcs_message_t * msg) {
   connfd=ldcs_socket_fdlist[fd].fd;
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("sending message of type: %s len=%d data=%s ...\n",
+  debug_printf3("sending message of type: %s len=%zu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
 
@@ -266,7 +271,8 @@ int ldcs_send_msg_socket(int fd, ldcs_message_t * msg) {
 ldcs_message_t * ldcs_recv_msg_socket(int fd,  ldcs_read_block_t block) {
   ldcs_message_t *msg;
   char help[41];
-  int n, connfd;
+  size_t n;
+  int connfd, err;
   if ((fd<0) || (fd>MAX_FD) )  _error("wrong fd");
   connfd=ldcs_socket_fdlist[fd].fd;
 
@@ -274,20 +280,20 @@ ldcs_message_t * ldcs_recv_msg_socket(int fd,  ldcs_read_block_t block) {
   if (!msg)  _error("could not allocate memory for message");
   
 
-  n = _ldcs_read_socket(connfd,&msg->header,sizeof(msg->header), block);
+  n = _ldcs_read_socket(connfd,&msg->header,sizeof(msg->header), block, &err);
+  if (err) _error("ERROR reading header from socket");
   if (n == 0) {
     free(msg);
     return(NULL);
   }
-  if (n < 0) _error("ERROR reading header from socket");
 
   if(msg->header.len>0) {
 
     msg->data = (char *) malloc(msg->header.len);
     if (!msg)  _error("could not allocate memory for message data");
     
-    n = _ldcs_read_socket(connfd,msg->data,msg->header.len, LDCS_READ_BLOCK);
-    if (n < 0) _error("ERROR reading message data from socket");
+    n = _ldcs_read_socket(connfd,msg->data,msg->header.len, LDCS_READ_BLOCK, &err);
+    if (err) _error("ERROR reading message data from socket");
     if (n != msg->header.len) _error("received different number of bytes for message data");
 
   } else {
@@ -295,7 +301,7 @@ ldcs_message_t * ldcs_recv_msg_socket(int fd,  ldcs_read_block_t block) {
   }
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("received message of type: %s len=%d data=%s ...\n",
+  debug_printf3("received message of type: %s len=%zu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
   
@@ -306,31 +312,32 @@ ldcs_message_t * ldcs_recv_msg_socket(int fd,  ldcs_read_block_t block) {
 int ldcs_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_t block) {
   char help[41];
   int rc=0;
-  int n, connfd;
+  size_t n;
+  int connfd, err;
   if ((fd<0) || (fd>MAX_FD) )  _error("wrong fd");
   connfd=ldcs_socket_fdlist[fd].fd;
 
 
-  n = _ldcs_read_socket(connfd,&msg->header,sizeof(msg->header), block);
+  n = _ldcs_read_socket(connfd,&msg->header,sizeof(msg->header), block, &err);
+  if (err) _error("ERROR reading header from socket");
   if (n == 0) return(rc);
-  if (n < 0) _error("ERROR reading header from socket");
 
   if(msg->header.len>0) {
 
     msg->data = (char *) malloc(msg->header.len);
     if (!msg)  _error("could not allocate memory for message data");
     
-    n = _ldcs_read_socket(connfd,msg->data,msg->header.len, LDCS_READ_BLOCK);
-    if (n == 0) return(rc);
-    if (n < 0) _error("ERROR reading message data from socket");
+    n = _ldcs_read_socket(connfd,msg->data,msg->header.len, LDCS_READ_BLOCK, &err);
+    if (err) _error("ERROR reading message data from socket");
     if (n != msg->header.len) _error("received different number of bytes for message data");
+    if (n == 0) return(rc);
 
   } else {
     msg->data = NULL;
   }
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("received message of type: %s len=%d data=%s ...\n",
+  debug_printf3("received message of type: %s len=%zu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
   
@@ -344,5 +351,7 @@ int ldcs_get_aux_fd_socket()
 
 int ldcs_socket_id_to_nc_socket(int id, int fd, ldcs_process_data_t *process_data)
 {
+   fd=fd;
+   process_data=process_data;
    return id;
 }

--- a/src/utils/exitnote.c
+++ b/src/utils/exitnote.c
@@ -56,10 +56,10 @@ static char *exitSocketPath(const char *location)
       endslash = "/";
 
    result = snprintf(socketpath, sizeof(socketpath), "%s%sspindle_bext_%s", location, endslash, hostname);
-   if (result > sizeof(socketpath)) {
+   if (result > (int)sizeof(socketpath)) {
       snprintf(socketpath, sizeof(socketpath), "%s%s%x", location, endslash, badhash(hostname));
    }
-   if (result > sizeof(socketpath)) {
+   if (result > (int)sizeof(socketpath)) {
       err_printf("Could not fit socket path %s%sspindle_bext_%s into max socket path of %lu\n",
                  location, endslash, hostname, (unsigned long) sizeof(socketpath));
       return NULL;

--- a/src/utils/fileutil.c
+++ b/src/utils/fileutil.c
@@ -26,9 +26,10 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 int read_n_bytes(char *localname, int fd, void *buffer, size_t size)
 {
-   int result, bytes_read, error;
+   int result, error;
+   size_t bytes_read;
    bytes_read = 0;
-   debug_printf3("Reading %ld bytes from %s\n", size, localname);
+   debug_printf3("Reading %zu bytes from %s\n", size, localname);
 
    while (bytes_read != size) {
       errno = 0;
@@ -37,7 +38,7 @@ int read_n_bytes(char *localname, int fd, void *buffer, size_t size)
          error = errno;
          if (error == EAGAIN || error == EINTR)
             continue;
-         err_printf("Failed to read from file %s of size %lu (already read %d): %s\n",
+         err_printf("Failed to read from file %s of size %zu (already read %zu): %s\n",
                     localname, size, bytes_read, strerror(error));
          close(fd);
          return -1;
@@ -77,9 +78,8 @@ int read_buffer(char *localname, char *buffer, int size)
 
 int write_n_bytes(char *localname, int fd, void *buffer, size_t size)
 {
-   int result, bytes_written;
-
-   bytes_written = 0;
+   int result;
+   size_t bytes_written = 0;
 
    while (bytes_written != size) {
       result = write(fd, ((char *) buffer) + bytes_written, size - bytes_written);

--- a/src/utils/keyfile.c
+++ b/src/utils/keyfile.c
@@ -45,6 +45,9 @@ void get_keyfile_path(char *pathname, int pathname_len, uint64_t unique_id)
    snprintf(pathname, pathname_len, "%s/spindle_key.%d.%lu", demangled_loc, getuid(), (unsigned long) unique_id);
    pathname[pathname_len-1] = '\0';
 #else
+   pathname=pathname;
+   pathname_len=pathname_len;
+   unique_id=unique_id;
    assert(0 && "Tried to use keyfile when not compiled with keyfile.");
 #endif
 }
@@ -80,7 +83,7 @@ void create_keyfile(uint64_t unique_id)
 {
    char path[MAX_PATH_LEN+1];
    int key_fd, result;
-   int bytes_written;
+   size_t bytes_written;
    char *last_slash;
    struct stat buf;
    unsigned char key[KEY_SIZE_BYTES];

--- a/src/utils/parseloc.c
+++ b/src/utils/parseloc.c
@@ -223,13 +223,13 @@ char **parse_colonsep_prefixes(char *colonsep_list, number_t number)
       prefixes[0] = NULL;
       return prefixes;
    }
-   int numprefixes = 1;
+   size_t numprefixes = 1;
    for (size_t i = 0; s[i] != '\0'; i++) {
       if (s[i] == ':') {
          numprefixes++;
       }
    }   
-   int num_strs = numprefixes + 1;
+   size_t num_strs = numprefixes + 1;
    
    prefixes = (char **) malloc(sizeof(char*) * num_strs);
    size_t i = 0, cur = 0;


### PR DESCRIPTION
Fixes warnings generated by gcc 15.1.0 and `-Wall -Wextra -Werror`.

The vast majority are either unused parameters or comparing incompatible types (signed vs unsigned).  I handled the former by adding `foo=foo;` (or, in C++ code, removing the parameter name from the function signature).  The latter could be a bit more involved, but generally if a variable contains a count of things in memory, it's now `size_t`, with a few workarounds to handle glibc calls that were defined in less suspicious times.

A single case of intentional fallthrough is now marked with `[[ fallthrough ]]`. This feature has been available in gcc since v10.0 and is now part of the C23 standard.  If we have users with older compilers, there are other possible workarounds.

The single (fixed) bug uncovered was an unintentional fallthrough.  

I can chop this up into smaller (per file?) chunks if that's useful.

Fixes #94 