### PR TITLE
Fix failures in symbind_test found on Ubuntu

### DIFF
--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -316,7 +316,7 @@ origin_dir/liboriginlib.so: originlib.c $(REGLIB_SRC) origin_dir/origin_subdir/l
 	$(AM_V_CCLD)$(MPICC) -o $@ -fPIC -Wall $< $(REGLIB_SRC) -DSO_NAME=liboriginlib.so -DFUNC_NAME=origin_calc -shared '-Wl,-rpath,$$ORIGIN/origin_subdir' -Lorigin_dir/origin_subdir -lorigintarget
 
 libsymbind_a.so: $(srcdir)/symbindlib.c $(srcdir)/symbind_fileops.c libsymbind_b.so
-	$(AM_V_CCLD)$(CC) $(CFLAGS) -o $@ -shared -fPIC -Wall -DAUTORUN=a $(srcdir)/symbindlib.c -L. -lsymbind_b -I$(srcdir) -Wl,-rpath,$(top_builddir)/testsuite
+	$(AM_V_CCLD)$(CC) $(CFLAGS) -o $@ -shared -fPIC -Wall -DAUTORUN=a $(srcdir)/symbindlib.c -L. -Wl,--no-as-needed -lsymbind_b -I$(srcdir) -Wl,-rpath,$(top_builddir)/testsuite
 
 libsymbind_b.so: $(srcdir)/symbindlib.c $(srcdir)/symbind_fileops.c
 	$(AM_V_CCLD)$(CC) $(CFLAGS) -o $@ -shared -fPIC -Wall -DAUTORUN=b $(srcdir)/symbindlib.c -I$(srcdir) -Wl,-rpath,$(top_builddir)/testsuite
@@ -334,11 +334,11 @@ libsymbind_f.so: $(srcdir)/symbindlib.c $(srcdir)/symbind_fileops.c
 	$(AM_V_CCLD)$(CC) $(CFLAGS) -fno-plt -o $@ -shared -fPIC -Wall $(srcdir)/symbindlib.c -I$(srcdir) -Wl,-rpath,$(top_builddir)/testsuite
 
 libsymbind_g.so: $(srcdir)/symbindlib_g.c
-	$(AM_V_CC)$(CC) $(CFLAGS) -c -o symbindlib_g.o -shared -fPIC -Wall $(srcdir)/symbindlib_g.c -I$(srcdir)
+	$(AM_V_CC)$(CC) $(CFLAGS) -c -o symbindlib_g.o -shared -fPIC -fno-stack-protector -Wall $(srcdir)/symbindlib_g.c -I$(srcdir)
 	$(AM_V_CCLD)$(LD) -shared -o $@ symbindlib_g.o -rpath $(top_builddir)/testsuite
 
 symbind_test: $(srcdir)/symbind_test.c $(srcdir)/symbind_fileops.c libsymbind_a.so libsymbind_b.so libsymbind_c.so libsymbind_d.so libsymbind_e.so libsymbind_f.so libsymbind_g.so
-	$(AM_V_CCLD)$(CC) $(CFLAGS) -o $@ -Wall $(srcdir)/symbind_test.c -L. -lsymbind_a -I$(srcdir) -ldl -Wl,-rpath,$(top_builddir)/testsuite
+	$(AM_V_CCLD)$(CC) $(CFLAGS) -o $@ -Wall $(srcdir)/symbind_test.c -L. -Wl,--no-as-needed -lsymbind_a -I$(srcdir) -ldl -Wl,-rpath,$(top_builddir)/testsuite
 
 retzero_rx: retzero.c
 	$(AM_V_CCLD)$(MPICC) -o $@ $<

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -991,7 +991,7 @@ origin_dir/liboriginlib.so: originlib.c $(REGLIB_SRC) origin_dir/origin_subdir/l
 	$(AM_V_CCLD)$(MPICC) -o $@ -fPIC -Wall $< $(REGLIB_SRC) -DSO_NAME=liboriginlib.so -DFUNC_NAME=origin_calc -shared '-Wl,-rpath,$$ORIGIN/origin_subdir' -Lorigin_dir/origin_subdir -lorigintarget
 
 libsymbind_a.so: $(srcdir)/symbindlib.c $(srcdir)/symbind_fileops.c libsymbind_b.so
-	$(AM_V_CCLD)$(CC) $(CFLAGS) -o $@ -shared -fPIC -Wall -DAUTORUN=a $(srcdir)/symbindlib.c -L. -lsymbind_b -I$(srcdir) -Wl,-rpath,$(top_builddir)/testsuite
+	$(AM_V_CCLD)$(CC) $(CFLAGS) -o $@ -shared -fPIC -Wall -DAUTORUN=a $(srcdir)/symbindlib.c -L. -Wl,--no-as-needed -lsymbind_b -I$(srcdir) -Wl,-rpath,$(top_builddir)/testsuite
 
 libsymbind_b.so: $(srcdir)/symbindlib.c $(srcdir)/symbind_fileops.c
 	$(AM_V_CCLD)$(CC) $(CFLAGS) -o $@ -shared -fPIC -Wall -DAUTORUN=b $(srcdir)/symbindlib.c -I$(srcdir) -Wl,-rpath,$(top_builddir)/testsuite
@@ -1009,11 +1009,11 @@ libsymbind_f.so: $(srcdir)/symbindlib.c $(srcdir)/symbind_fileops.c
 	$(AM_V_CCLD)$(CC) $(CFLAGS) -fno-plt -o $@ -shared -fPIC -Wall $(srcdir)/symbindlib.c -I$(srcdir) -Wl,-rpath,$(top_builddir)/testsuite
 
 libsymbind_g.so: $(srcdir)/symbindlib_g.c
-	$(AM_V_CC)$(CC) $(CFLAGS) -c -o symbindlib_g.o -shared -fPIC -Wall $(srcdir)/symbindlib_g.c -I$(srcdir)
+	$(AM_V_CC)$(CC) $(CFLAGS) -c -o symbindlib_g.o -shared -fPIC -fno-stack-protector -Wall $(srcdir)/symbindlib_g.c -I$(srcdir)
 	$(AM_V_CCLD)$(LD) -shared -o $@ symbindlib_g.o -rpath $(top_builddir)/testsuite
 
 symbind_test: $(srcdir)/symbind_test.c $(srcdir)/symbind_fileops.c libsymbind_a.so libsymbind_b.so libsymbind_c.so libsymbind_d.so libsymbind_e.so libsymbind_f.so libsymbind_g.so
-	$(AM_V_CCLD)$(CC) $(CFLAGS) -o $@ -Wall $(srcdir)/symbind_test.c -L. -lsymbind_a -I$(srcdir) -ldl -Wl,-rpath,$(top_builddir)/testsuite
+	$(AM_V_CCLD)$(CC) $(CFLAGS) -o $@ -Wall $(srcdir)/symbind_test.c -L. -Wl,--no-as-needed -lsymbind_a -I$(srcdir) -ldl -Wl,-rpath,$(top_builddir)/testsuite
 
 retzero_rx: retzero.c
 	$(AM_V_CCLD)$(MPICC) -o $@ $<

--- a/testsuite/symbind_test.c
+++ b/testsuite/symbind_test.c
@@ -32,6 +32,7 @@ const char *unknown_dso = "[unknown dso]";
 
 typedef struct {
    const char *symname;
+   const char *altname;
    const char *libtarget;
    const char *libmatched;
    void *got_ptr;
@@ -160,7 +161,7 @@ static int check_relocations(REL_TYPE *rels, unsigned long num_rels, ElfW(Addr) 
       for (test_i = 0; test[test_i].symname; test_i++) {
          if (strcmp(name, "dlopen") == 0)
             continue;
-         if (strstr(name, test[test_i].symname)) {
+         if (strstr(name, test[test_i].symname) || (test[test_i].altname && strstr(name, test[test_i].altname))) {
             break;
          }
       }
@@ -299,13 +300,13 @@ void *runtest_for_lib(const char *libname, int options)
       libspindle = "libc.so";
 
    test_bindings_t test[] = {
-      { "getpid", "libc.so", NULL, NULL, 0 },
-      { "readlink", libspindle, NULL, NULL, 0 },
-      { "open", libspindle, NULL, NULL, 0 },
-      { "read", "libc.so", NULL, NULL, 0 },
-      { "fxstat", libspindle, NULL, NULL, 0 },
-      { "lxstat", libspindle, NULL, NULL, 0 },      
-      { "xstat", libspindle, NULL, NULL, 0 },
+      { "getpid", NULL, "libc.so", NULL, NULL, 0 },
+      { "readlink", NULL, libspindle, NULL, NULL, 0 },
+      { "open", NULL, libspindle, NULL, NULL, 0 },
+      { "read", NULL, "libc.so", NULL, NULL, 0 },
+      { "fxstat", "fstat", libspindle, NULL, NULL, 0 },
+      { "lxstat", "lstat", libspindle, NULL, NULL, 0 },
+      { "xstat", "stat", libspindle, NULL, NULL, 0 },
       { NULL, NULL, NULL, NULL, 0 }
    };
 


### PR DESCRIPTION
Fixes three problems with symbind_test discovered when testing on Ubuntu: 

1. `symbind_test` did not account for differences in symbol names for the stat family of functions in different version of glibc. Fixed by adding an alternate name and accepting either name.

2. Where GCC is configured to link with `--as-needed` by default, `symbind_test` would not be linked against `libsymbind_a.so`, nor would `libsymbind_a.so` be linked against `libsymbind_b.so`. Fixed by explicitly specifying `-Wl,--no-as-needed` when linking `symbind_test` and `libsymbind_a.so`. 

3. `libsymbind_g.so` was intended to not have a PLT, but where GCC is configured to use `-fstack-protector` by default, one is present. Fixed by explicitly specifying `-fno-stack-protector` when compiling `libsymbing_g.c`. 

These are the minimal fixes which, together with #97, allow the whole testsuite to pass under the containerized CI environment. 

This does not fix the issue where the presence of a PLT that contains only the entry for the stack protector prevents Spindle binding from occurring correctly; that will be addressed in a forthcoming PR.