### PR TITLE
Fix issue with large files over signed int size causing problems in network code

### DIFF
--- a/src/client/client_comlib/client_api.c
+++ b/src/client/client_comlib/client_api.c
@@ -57,7 +57,7 @@ int send_file_query(int fd, char* path, int dso, char** newpath, int *errcode) {
 
    COMM_LOCK;
 
-   debug_printf3("sending message of type: file_query len=%d data='%s' ...(%s)\n",
+   debug_printf3("sending message of type: file_query len=%lu data='%s' ...(%s)\n",
                  message.header.len, message.data, path);  
    client_send_msg(fd, &message);
 
@@ -105,7 +105,7 @@ int send_stat_request(int fd, char *path, int is_lstat, char *newpath)
    
    COMM_LOCK;
 
-   debug_printf3("sending message of type: %sstat_query len=%d data='%s' ...(%s)\n",
+   debug_printf3("sending message of type: %sstat_query len=%lu data='%s' ...(%s)\n",
                  is_lstat ? "l" : "", message.header.len, message.data, path);  
    client_send_msg(fd, &message);
 
@@ -149,7 +149,7 @@ int send_existance_test(int fd, char *path, int *exists)
    message.header.len = strlen(path) + 1;
    message.data = (void *) buffer;
 
-   debug_printf3("Sending message of type: file_exist_query len=%d, data=%s\n",
+   debug_printf3("Sending message of type: file_exist_query len=%lu, data=%s\n",
                  message.header.len, path);
    COMM_LOCK;
 
@@ -186,7 +186,7 @@ int send_orig_path_request(int fd, const char *path, char *newpath)
    message.header.len = strlen(path) + 1;
    message.data = (void *) buffer;
 
-   debug_printf3("Sending message of type: file_orig_path len=%d, data=%s\n",
+   debug_printf3("Sending message of type: file_orig_path len=%lu, data=%s\n",
                  message.header.len, path);
    COMM_LOCK;
 

--- a/src/client/client_comlib/client_api_biter.c
+++ b/src/client/client_comlib/client_api_biter.c
@@ -72,7 +72,7 @@ int client_send_msg_biter(int connid, ldcs_message_t *msg)
       return -1;
    }
 
-   debug_printf3("sending message of size len=%d\n", msg->header.len);
+   debug_printf3("sending message of size len=%lu\n", msg->header.len);
 
    result = biterc_write(connid, &msg->header, sizeof(msg->header));
    if (result == -1) {

--- a/src/client/client_comlib/client_api_pipe.c
+++ b/src/client/client_comlib/client_api_pipe.c
@@ -320,7 +320,7 @@ int client_send_msg_pipe(int fd, ldcs_message_t *msg) {
 
    assert(fd >= 0 && fd < MAX_FD);
    
-   debug_printf3("sending message of size len=%d\n", msg->header.len);
+   debug_printf3("sending message of size len=%lu\n", msg->header.len);
    
    result = write_pipe(fdlist_pipe[fd].out_fd, &msg->header, sizeof(msg->header));
    if (result == -1)
@@ -360,7 +360,7 @@ static int client_recv_msg_pipe(int fd, ldcs_message_t *msg, ldcs_read_block_t b
       msg->data = (char *) spindle_malloc(msg->header.len);
    }
 
-   debug_printf3("Reading %d bytes for payload from pipe\n", msg->header.len);
+   debug_printf3("Reading %lu bytes for payload from pipe\n", msg->header.len);
    result = read_pipe(fdlist_pipe[fd].in_fd, msg->data, msg->header.len);
    return result;
 }

--- a/src/client/client_comlib/client_api_socket.c
+++ b/src/client/client_comlib/client_api_socket.c
@@ -198,7 +198,7 @@ int client_send_msg_socket(int fd, ldcs_message_t * msg) {
   connfd=ldcs_socket_fdlist[fd].fd;
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("sending message of type: %s len=%d data=%s ...\n",
+  debug_printf3("sending message of type: %s len=%lu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
 
@@ -241,7 +241,7 @@ int client_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_
   }
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("received message of type: %s len=%d data=%s ...\n",
+  debug_printf3("received message of type: %s len=%lu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
   

--- a/src/include/ldcs_api.h
+++ b/src/include/ldcs_api.h
@@ -112,7 +112,7 @@ typedef  enum {
 struct ldcs_message_header_struct
 {
   ldcs_message_ids_t type;
-  int len;
+  size_t len;
 };
 
 typedef struct ldcs_message_header_struct ldcs_message_header_t;

--- a/src/server/auditserver/ldcs_audit_server_filemngt.c
+++ b/src/server/auditserver/ldcs_audit_server_filemngt.c
@@ -190,7 +190,7 @@ int filemngt_read_file(char *filename, void *buffer, size_t *size, int strip,
 int filemngt_encode_packet(char *filename, void *filecontents, size_t filesize, int stripped,
                            char **buffer, size_t *buffer_size)
 {
-   int cur_pos = 0;
+   size_t cur_pos = 0;
    int filename_len = strlen(filename) + 1;
    int is_elf = filemngt_is_elf_file(filecontents, filesize);
    //TODO: Remove filesize from allocation if we're doing a non-contig send. Wastes memory.
@@ -227,7 +227,7 @@ int filemngt_encode_packet(char *filename, void *filecontents, size_t filesize, 
    return 0;
 }
 
-int filemngt_decode_packet(node_peer_t peer, ldcs_message_t *msg, char *filename, size_t *filesize, int *bytes_read, int *is_elf, int *stripped)
+int filemngt_decode_packet(node_peer_t peer, ldcs_message_t *msg, char *filename, size_t *filesize, size_t *bytes_read, int *is_elf, int *stripped)
 {
    int filename_len = 0;
    int result;
@@ -259,7 +259,7 @@ int filemngt_decode_packet(node_peer_t peer, ldcs_message_t *msg, char *filename
       *bytes_read = sizeof(filename_len) + sizeof(*filesize) + filename_len;
    }
    else {
-      int pos = 0;
+      size_t pos = 0;
       unsigned char *data = (unsigned char *) msg->data;
       *is_elf = *((int *) (data+pos));
       pos += sizeof(int);

--- a/src/server/auditserver/ldcs_audit_server_filemngt.h
+++ b/src/server/auditserver/ldcs_audit_server_filemngt.h
@@ -28,7 +28,7 @@ int ldcs_audit_server_filemngt_init (char* location);
 int filemngt_read_file(char *filename, void *buffer, size_t *size, int strip, int *err, int *was_stripped);
 int filemngt_encode_packet(char *filename, void *filecontents, size_t filesize, 
                            int stripped, char **buffer, size_t *buffer_size);
-int filemngt_decode_packet(node_peer_t peer, ldcs_message_t *msg, char *filename, size_t *buffer_size, int *bytes_read, int *is_elf, int *stripped);
+int filemngt_decode_packet(node_peer_t peer, ldcs_message_t *msg, char *filename, size_t *buffer_size, size_t *bytes_read, int *is_elf, int *stripped);
 
 typedef enum {
    clt_unknown,

--- a/src/server/auditserver/ldcs_audit_server_handlers.c
+++ b/src/server/auditserver/ldcs_audit_server_handlers.c
@@ -1563,8 +1563,8 @@ static int handle_file_recv(ldcs_process_data_t *procdata, ldcs_message_t *msg, 
 {
    char pathname[MAX_PATH_LEN+1], *localname;
    char *buffer = NULL;
-   size_t size = 0;
-   int result, global_error = 0, already_loaded, fd = -1, bytes_read = 0, is_stripped = 0;
+   size_t size = 0, bytes_read = 0;
+   int result, global_error = 0, already_loaded, fd = -1, is_stripped = 0;
    int replicate, is_elf;
    
    pathname[MAX_PATH_LEN] = '\0';

--- a/src/server/comlib/ldcs_api_biter.c
+++ b/src/server/comlib/ldcs_api_biter.c
@@ -167,7 +167,7 @@ int ldcs_send_msg_biter(int fd, ldcs_message_t *msg)
    
    if (spindle_debug_prints) {
       int rank = biterd_get_rank(session, proc);
-      debug_printf3("Sending message of size %d to rank %d (session = %d, proc = %d)\n",
+      debug_printf3("Sending message of size %lu to rank %d (session = %d, proc = %d)\n",
                     msg->header.len, rank, session, proc);
    }
    
@@ -183,7 +183,7 @@ int ldcs_send_msg_biter(int fd, ldcs_message_t *msg)
 
    result = biterd_write(session, proc, msg->data, msg->header.len);
    if (result == -1) {
-      err_printf("Error writing message of size %d to session %d, proc %d: %s\n",
+      err_printf("Error writing message of size %lu to session %d, proc %d: %s\n",
                  msg->header.len, session, proc, biterd_lasterror_str());
       return -1;
    }
@@ -271,7 +271,7 @@ int ldcs_recv_msg_static_biter(int connid, ldcs_message_t *msg, ldcs_read_block_
       return -1;
    }
 
-   debug_printf3("Message to be read is of size %d (session = %d, proc = %d)\n",
+   debug_printf3("Message to be read is of size %lu (session = %d, proc = %d)\n",
                  msg->header.len, session, proc);
    
    if (msg->header.len == 0) {
@@ -281,7 +281,7 @@ int ldcs_recv_msg_static_biter(int connid, ldcs_message_t *msg, ldcs_read_block_
 
    result = biterd_read(session, proc, msg->data, msg->header.len);
    if (result == -1) {
-      err_printf("Error reading message of size %d from session %d, proc %d: %s\n",
+      err_printf("Error reading message of size %lu from session %d, proc %d: %s\n",
                  msg->header.len, session, proc, biterd_lasterror_str());
       return -1;
    }

--- a/src/server/comlib/ldcs_api_pipe.c
+++ b/src/server/comlib/ldcs_api_pipe.c
@@ -274,7 +274,7 @@ int ldcs_send_msg_pipe(int fd, ldcs_message_t * msg) {
 
   if ((fd<0) || (fd>fdlist_pipe_size) )  _error("wrong fd");
   
-  debug_printf3("sending message of type: %s len=%d data=%s ...\n",
+  debug_printf3("sending message of type: %s len=%lu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,msg->data );  
 
@@ -319,7 +319,7 @@ ldcs_message_t * ldcs_recv_msg_pipe(int fd, ldcs_read_block_t block ) {
     msg->data = NULL;
   }
 
-  debug_printf3("received message of type: %s len=%d data=%s ...\n",
+  debug_printf3("received message of type: %s len=%lu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len, msg->data );
 
@@ -365,7 +365,7 @@ int ldcs_recv_msg_static_pipe(int fd, ldcs_message_t *msg, ldcs_read_block_t blo
     *msg->data = '\0';
   }
 
-  debug_printf3("received message of type: %s len=%d data=%s ...\n",
+  debug_printf3("received message of type: %s len=%lu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len, msg->data );
 

--- a/src/server/comlib/ldcs_api_socket.c
+++ b/src/server/comlib/ldcs_api_socket.c
@@ -247,7 +247,7 @@ int ldcs_send_msg_socket(int fd, ldcs_message_t * msg) {
   connfd=ldcs_socket_fdlist[fd].fd;
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("sending message of type: %s len=%d data=%s ...\n",
+  debug_printf3("sending message of type: %s len=%lu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
 
@@ -295,7 +295,7 @@ ldcs_message_t * ldcs_recv_msg_socket(int fd,  ldcs_read_block_t block) {
   }
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("received message of type: %s len=%d data=%s ...\n",
+  debug_printf3("received message of type: %s len=%lu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
   
@@ -330,7 +330,7 @@ int ldcs_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_t 
   }
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("received message of type: %s len=%d data=%s ...\n",
+  debug_printf3("received message of type: %s len=%lu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
   


### PR DESCRIPTION
We hit a problem where spindle relocated a file larger than 32-bit signed int. This broke some int-based network code. This commit moves network communication to 64-bit unsigned size_t.