### PR TITLE
Adds disconnect handling to client comms.

### DIFF
--- a/src/client/client/client.c
+++ b/src/client/client/client.c
@@ -312,6 +312,8 @@ void test_log(const char *name)
    int result;
    if (!run_tests)
       return;
+   if (client_is_disconnected() && strcmp(getenv("SPINDLE_TEST"), "TEST_RELIABILITY") == 0)
+      return;
    result = open(name, O_RDONLY);
    if (result != -1)
       close(result);
@@ -445,6 +447,7 @@ char *client_library_load(const char *name)
 {
    char *newname;
    int errcode, direxists;
+   int result;
    char fixed_name[MAX_PATH_LEN+1];
 
    check_for_fork();
@@ -469,7 +472,11 @@ char *client_library_load(const char *name)
    if (is_in_spindle_cache(name)) {
       debug_printf2("Library %s is in spindle cache (%s). Translating request\n", name, location);
       memset(fixed_name, 0, MAX_PATH_LEN+1);
-      send_orig_path_request(ldcsid, orig_file_name, fixed_name);
+      result = send_orig_path_request(ldcsid, orig_file_name, fixed_name);
+      if (result == DISCONNECT) {
+         debug_printf2("Client is in disconnected state. Returning %s for loading\n", name);
+         return (char *) name;
+      }
       orig_file_name = fixed_name;
       debug_printf2("Spindle cache library %s translated to original path %s\n", name, orig_file_name);
    }
@@ -488,8 +495,12 @@ char *client_library_load(const char *name)
       return (char *) name;
    }
    
-   get_relocated_file(ldcsid, orig_file_name, 1, &newname, &errcode, &direxists);
- 
+   result = get_relocated_file(ldcsid, orig_file_name, 1, &newname, &errcode, &direxists);
+   if (result == DISCONNECT) {
+      debug_printf2("Client is in disconnected state. Returning %s for loading\n", name);
+      return (char *) name;
+   }
+
    if(!newname) {
       newname = concatStrings(NOT_FOUND_PREFIX, orig_file_name);
       if (!direxists)
@@ -508,13 +519,18 @@ static void read_python_prefixes(int fd, char **path)
 {
    int use_cache = (opts & OPT_SHMCACHE) && (shm_cachesize > 0);
    int found_file = 0;
+   int result;
 
    if (use_cache) {
       debug_printf2("Looking up python prefixes in shared cache\n");
       found_file = fetch_from_cache("*SPINDLE_PYTHON_PREFIXES", path);
    }
    if (!found_file) {
-      get_python_prefix(fd, path);
+      result = get_python_prefix(fd, path);
+      if (result == DISCONNECT) {
+         debug_printf2("Spindle disconnected. Using empty python prefixes\n");
+         (*path)[0] = '\0';
+      }
       if (use_cache)
          shmcache_update("*SPINDLE_PYTHON_PREFIXES", *path);
    }
@@ -600,7 +616,11 @@ static ldso_info_t *load_ldso_metadata()
    }
 
    if (!found_file) {
-      send_ldso_info_request(ldcsid, interp_name, filename);
+      result = send_ldso_info_request(ldcsid, interp_name, filename);
+      if (result == DISCONNECT) {
+         debug_printf2("Client disconnected. No ldso info\n");
+         return NULL;
+      }
       if (use_cache)
          shmcache_update(cachename, filename);
       ldso_info_name = filename;

--- a/src/client/client/exec_util.c
+++ b/src/client/client/exec_util.c
@@ -220,6 +220,7 @@ int exec_pathsearch(int ldcsid, const char *orig_exec, char **reloc_exec, int *e
 {
    char *saveptr = NULL, *path, *cur;
    char newexec[MAX_PATH_LEN+1];
+   int result;
 
    if (!orig_exec) {
       err_printf("Null exec passed to exec_pathsearch\n");
@@ -228,14 +229,22 @@ int exec_pathsearch(int ldcsid, const char *orig_exec, char **reloc_exec, int *e
    }
    
    if (orig_exec[0] == '/' || orig_exec[0] == '.') {
-      get_relocated_file(ldcsid, (char *) orig_exec, 1, reloc_exec, errcode, NULL);
+      result = get_relocated_file(ldcsid, (char *) orig_exec, 1, reloc_exec, errcode, NULL);
+      if (result == DISCONNECT) {
+         debug_printf3("Disconnected during exec\n");
+         return DISCONNECT;
+      }
       debug_printf3("exec_pathsearch translated %s to %s\n", orig_exec, *reloc_exec);
       return 0;
    }
 
    path = getenv("PATH");
    if (!path) {
-      get_relocated_file(ldcsid, (char *) orig_exec, 1, reloc_exec, errcode, NULL);
+      result = get_relocated_file(ldcsid, (char *) orig_exec, 1, reloc_exec, errcode, NULL);
+      if (result == DISCONNECT) {
+         debug_printf3("Disconnected during exec\n");
+         return DISCONNECT;
+      }
       debug_printf3("No path.  exec_pathsearch translated %s to %s\n", orig_exec, *reloc_exec);
       return 0;
    }
@@ -256,6 +265,11 @@ int exec_pathsearch(int ldcsid, const char *orig_exec, char **reloc_exec, int *e
          result = stat(newexec, &buf);
          exists = (result != -1);
       }
+      if (result == DISCONNECT) {
+         debug_printf3("Disconnected during exec\n");
+         if (path) spindle_free(path);
+         return DISCONNECT;
+      }
       if (!exists)
          continue;
       if (buf.st_mode & S_IFDIR) {
@@ -269,7 +283,12 @@ int exec_pathsearch(int ldcsid, const char *orig_exec, char **reloc_exec, int *e
          continue;
       }
       debug_printf2("File %s exists and has execute set, requesting full file\n", newexec);
-      get_relocated_file(ldcsid, newexec, 1, reloc_exec, errcode, NULL);
+      result = get_relocated_file(ldcsid, newexec, 1, reloc_exec, errcode, NULL);
+      if (result == DISCONNECT) {
+         debug_printf3("Disconnected during exec\n");
+         if (path) spindle_free(path);
+         return DISCONNECT;
+      }
       debug_printf2("Exec search request returned %s -> %s\n", newexec, *reloc_exec ? *reloc_exec : "NULL");
       if (*reloc_exec) {
          found = 1;

--- a/src/client/client/intercept_exec.c
+++ b/src/client/client/intercept_exec.c
@@ -251,16 +251,8 @@ static int prep_exec(const char *filepath, char **argv,
 {
    int result;
    char *interp_name;
-   int i;
 
    debug_printf3("prep_exec for filepath %s to newpath %s\n", filepath, newpath);
-   if (spindle_debug_prints >= 3) {
-      debug_printf3("Args for exec are:\n");
-      for (i = 0; argv[i]; i++) {
-         debug_printf3("%d. %s\n", i, argv[i]);
-      }
-   }
-   
    
    if (errcode == EACCES) {
       strncpy(newpath, filepath, newpath_size);
@@ -327,6 +319,7 @@ static int find_exec(const char *filepath, char **argv, char *newpath, int newpa
    int errcode, exists;
    struct stat buf;
    int reloc_exec;
+   int result;
 
    *propogate_spindle = shouldPropogateSpindle(envp, filepath);
 
@@ -353,11 +346,19 @@ static int find_exec(const char *filepath, char **argv, char *newpath, int newpa
    sync_cwd();
    
    debug_printf2("Requesting stat on exec of %s to validate file\n", filepath);
-   int result = get_stat_result(ldcsid, (char *) filepath, 0, &exists, &buf);
+   result = get_stat_result(ldcsid, (char *) filepath, 0, &exists, &buf);
    if (result == STAT_SELF_OPEN) {
       result = stat(filepath, &buf);
       exists = (result != -1);
    }
+   else if (result == DISCONNECT) {
+      debug_printf3("Disconnected. Passing through original file %s\n", filepath);
+      *propogate_spindle = 0;
+      strncpy(newpath, filepath, newpath_size);
+      newpath[newpath_size-1] = '\0';
+      return 0;
+   }
+
    if (!exists) {
       set_errno(ENOENT);
       return -1;
@@ -370,7 +371,14 @@ static int find_exec(const char *filepath, char **argv, char *newpath, int newpa
       return -1;
    }
    debug_printf2("Exec operation requesting file: %s\n", filepath);
-   get_relocated_file(ldcsid, (char *) filepath, 1, &newname, &errcode, NULL);
+   result = get_relocated_file(ldcsid, (char *) filepath, 1, &newname, &errcode, NULL);
+   if (result == DISCONNECT) {
+      debug_printf3("Disconnected. Passing through original file %s\n", filepath);
+      *propogate_spindle = 0;
+      strncpy(newpath, filepath, newpath_size);
+      newpath[newpath_size-1] = '\0';
+      return 0;
+   }
    debug_printf("Exec file request returned %s -> %s with errcode %d\n",
                 filepath, newname ? newname : "NULL", errcode);
        
@@ -414,6 +422,13 @@ static int find_exec_pathsearch(const char *filepath, char **argv, char *newpath
    if (result == -1) {
       set_errno(errcode);
       return -1;
+   }
+   if (result == DISCONNECT) {
+      debug_printf3("Disconnected. Passing through original file %s\n", filepath);
+      *propogate_spindle = 0;
+      strncpy(newpath, filepath, newpath_size);
+      newpath[newpath_size-1] = '\0';
+      return 0;
    }
    debug_printf("Exec file request returned %s -> %s with errcode %d\n",
                 filepath, newname ? newname : "NULL", errcode);

--- a/src/client/client/intercept_open.c
+++ b/src/client/client/intercept_open.c
@@ -53,6 +53,7 @@ static int handle_proc_pid_maps_open(const char *path, char **newpath);
 static int do_check_file(const char *path, char **newpath) {
    char *myname, *newname;
    int errcode;
+   int result;
   
    myname=(char *) path;
    debug_printf2("Open operation requesting file: %s\n", path);
@@ -64,7 +65,11 @@ static int do_check_file(const char *path, char **newpath) {
    }
    sync_cwd();
 
-   get_relocated_file(ldcsid, myname, 0, &newname, &errcode, NULL);
+   result = get_relocated_file(ldcsid, myname, 0, &newname, &errcode, NULL);
+   if (result == DISCONNECT) {
+      debug_printf3("Disconnected. Access original file %s\n", path);
+      return -1;
+   }
 
    if (newname != NULL) {
       *newpath=newname;

--- a/src/client/client/intercept_readlink.c
+++ b/src/client/client/intercept_readlink.c
@@ -75,11 +75,13 @@ ssize_t readlink_wrapper(const char *path, char *buf, size_t bufsiz)
    else if (intercept_result == REDIRECT) {
       debug_printf3("Intercepting readlink(%s)\n", path);
       result = get_readlink_result(ldcsid, path, resultpath, &rl_result, &readlink_errcode);
-      if (result == -1 || result == STAT_SELF_OPEN) {
+      if (result == -1 || result == STAT_SELF_OPEN || result == DISCONNECT) {
          if (result == -1)
             err_printf("Spindle readlink returned error. Using orig readlink\n");
-         else
+         else if (result == STAT_SELF_OPEN)
             debug_printf3("Spindle readlink returned self open. Using orig readlink\n");
+         else if (result == DISCONNECT)
+            debug_printf3("Spindle disconnected. Using orig readlink\n");
          result = orig_readlink(path, resultpath, sizeof(resultpath));
          if (result == -1) {
             errno = get_errno();            

--- a/src/client/client/intercept_stat.c
+++ b/src/client/client/intercept_stat.c
@@ -52,7 +52,8 @@ int handle_stat(const char *path, struct stat *buf, int flags)
    if (ldcsid < 0 || !use_ldcs || !path || !buf) {
       debug_printf3("no ldcs: stat query %s\n", path ? path : "NULL");
       if (path)
-         test_log(path);      
+         test_log(path);
+      debug_printf3("Returning ORIG_STAT (%d)\n", (int) ORIG_STAT);
       return ORIG_STAT;
    }
    sync_cwd();
@@ -75,7 +76,11 @@ int handle_stat(const char *path, struct stat *buf, int flags)
       debug_printf3("Allowing original stat on %s\n", path);
       return ORIG_STAT;
    }
-   if (result == -1) {
+   else if (result == DISCONNECT) {
+      debug_printf3("Disconnected. Using riginal stat on %s\n", path);
+      return ORIG_STAT;
+   }
+   else if (result == -1) {
       /* Spindle level error */
       debug_printf3("Allowing original stat on %s\n", path);
       return ORIG_STAT;
@@ -128,7 +133,7 @@ static int handle_fstat(int fd, struct stat* buf, int flags)
    if (get_pathname_from_fd(fd, path, sizeof(path)) < 0)
       return -1;
 
-   debug_printf3("%s Redirecting fstat(%s) to the spindle\n", __func__, path);
+   debug_printf3("Redirecting fstat(%d=%s) to spindle\n", fd, path);
    return handle_stat(path, buf, flags);
 }
 
@@ -222,8 +227,10 @@ int rtcache_lxstat64(int vers, const char *path, struct stat *buf)
 int rtcache_fstat(int fd, struct stat *buf)
 {
    int result = handle_fstat(fd, buf, 0);
+   debug_printf3("handle_fstat returned %d (ORIG_STAT = %d)\n", result, (int) ORIG_STAT);
    if (result != ORIG_STAT)
       return result;
+   debug_printf3("Calling orig_fstat on fd %d\n", fd);
    result = orig_fstat(fd, buf);
    if (result == -1) {
       errno = get_errno();
@@ -235,8 +242,10 @@ int rtcache_fstat(int fd, struct stat *buf)
 int rtcache_fxstat(int vers, int fd, struct stat *buf)
 {
    int result = handle_fstat(fd, buf, IS_XSTAT);
+   debug_printf3("handle_fstat returned %d (ORIG_STAT = %d)\n", result, (int) ORIG_STAT);
    if (result != ORIG_STAT)
       return result;
+   debug_printf3("Calling orig_fxstat on fd %d\n", fd);
    result = orig_fxstat(vers, fd, buf);
    if (result == -1) {
       errno = get_errno();
@@ -247,9 +256,12 @@ int rtcache_fxstat(int vers, int fd, struct stat *buf)
 
 int rtcache_fxstat64(int vers, int fd, struct stat *buf)
 {
-   int result = handle_fstat(fd, buf, IS_XSTAT | IS_64);
+   int result;
+   result = handle_fstat(fd, buf, IS_XSTAT | IS_64);
+   debug_printf3("handle_fstat returned %d (ORIG_STAT = %d)\n", result, (int) ORIG_STAT);
    if (result != ORIG_STAT)
       return result;
+  debug_printf3("Calling orig_fxstat64 on fd %d\n", fd);
    result = orig_fxstat64(vers, fd, buf);
    if (result == -1) {
       errno = get_errno();

--- a/src/client/client/lookup.c
+++ b/src/client/client/lookup.c
@@ -258,14 +258,17 @@ static int get_metadata_result(int fd, const char *path, int is_lstat, int *exis
    if (!found_file) {
       debug_printf2("Sending request for %sstat of %s to server\n", is_lstat ? "l" : "", path);
       network_result = send_stat_request(fd, (char *) path, is_lstat, buffer);
-      debug_printf2("Server returned stat result for %s: %s\n", path, buffer);
-      
       if (network_result == -1)
          buffer[0] = '\0';
       if (network_result == STAT_SELF) {
          debug_printf3("Returning STAT_SELF_OPEN from get_metadata for %s\n", path);
          return STAT_SELF_OPEN;
       }
+      if (network_result == DISCONNECT) {
+         debug_printf3("Disconnected. Returning original stat for %s\n", path);
+         return STAT_SELF_OPEN;
+      }
+      debug_printf2("Server returned stat result for %s: %s\n", path, buffer);
 
       if (use_cache)
          update_cache(cache_name, dir_name, buffer, &errcode, ENOENT);
@@ -336,6 +339,9 @@ int get_relocated_file(int fd, const char *name, int dso, char** newname, int *e
 
    debug_printf2("Send file request to server: %s\n", name);
    result = send_file_query(fd, (char *) name, dso, newname, errorcode);
+   if (result == DISCONNECT) {
+      return DISCONNECT;
+   }
    debug_printf2("Recv file from server: %s\n", *newname ? *newname : "NONE");
 
    if (use_cache) {

--- a/src/client/client_comlib/client_api.c
+++ b/src/client/client_comlib/client_api.c
@@ -36,14 +36,32 @@ static struct lock_t comm_lock;
 
 #define COMM_LOCK do { if (lock(&comm_lock) == -1) return -1; } while (0)
 #define COMM_UNLOCK unlock(&comm_lock)
-   
+extern int ldcsid;
+
+static int is_disconnected = 0;
+static int bad_comm(int fd)
+{
+   debug_printf("Connection to server returned error. Setting client to disconnected\n");
+   close(fd);
+   ldcsid = -1;
+   is_disconnected = 1;
+   return DISCONNECT;
+}
+
+int client_is_disconnected()
+{
+   return is_disconnected;
+}
+
 int send_file_query(int fd, char* path, int dso, char** newpath, int *errcode) {
    ldcs_message_t message;
    char buffer[MAX_PATH_LEN+1+sizeof(int)];
    int result;
    int path_len = strlen(path)+1;
    buffer[MAX_PATH_LEN+sizeof(int)] = '\0';
-    
+
+   if (client_is_disconnected()) return DISCONNECT;
+
    if (path_len > MAX_PATH_LEN) {
       err_printf("Path to long for message");
       return -1;
@@ -57,12 +75,20 @@ int send_file_query(int fd, char* path, int dso, char** newpath, int *errcode) {
 
    COMM_LOCK;
 
-   debug_printf3("sending message of type: file_query len=%lu data='%s' ...(%s)\n",
+   debug_printf3("sending message of type: file_query len=%d data='%s' ...(%s)\n",
                  message.header.len, message.data, path);  
-   client_send_msg(fd, &message);
+   result = client_send_msg(fd, &message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    /* get new filename */
-   client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   result = client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -88,7 +114,10 @@ int send_file_query(int fd, char* path, int dso, char** newpath, int *errcode) {
 int send_stat_request(int fd, char *path, int is_lstat, char *newpath)
 {
    int path_len = strlen(path) + (is_lstat ? 0 : 1) + 1;
+   int result;
    ldcs_message_t message;
+
+   if (client_is_disconnected()) return DISCONNECT;
 
    if (path_len >= MAX_PATH_LEN+1) {
       err_printf("stat path of %s is too long for Spindle\n", path);
@@ -105,12 +134,21 @@ int send_stat_request(int fd, char *path, int is_lstat, char *newpath)
    
    COMM_LOCK;
 
-   debug_printf3("sending message of type: %sstat_query len=%lu data='%s' ...(%s)\n",
+   debug_printf3("sending message of type: %sstat_query len=%d data='%s' ...(%s)\n",
                  is_lstat ? "l" : "", message.header.len, message.data, path);  
-   client_send_msg(fd, &message);
+   result = client_send_msg(fd, &message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
+
 
    /* get new filename */
-   client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   result = client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -137,8 +175,10 @@ int send_existance_test(int fd, char *path, int *exists)
    ldcs_message_t message;
    char buffer[MAX_PATH_LEN+1];
    buffer[MAX_PATH_LEN] = '\0';
-   int path_len = strlen(path)+1;
-    
+   int path_len = strlen(path)+1, result;
+
+   if (client_is_disconnected()) return DISCONNECT;
+
    if (path_len > MAX_PATH_LEN) {
       err_printf("Path to long for message");
       return -1;
@@ -149,13 +189,21 @@ int send_existance_test(int fd, char *path, int *exists)
    message.header.len = strlen(path) + 1;
    message.data = (void *) buffer;
 
-   debug_printf3("Sending message of type: file_exist_query len=%lu, data=%s\n",
+   debug_printf3("Sending message of type: file_exist_query len=%d, data=%s\n",
                  message.header.len, path);
    COMM_LOCK;
 
-   client_send_msg(fd, &message);
+   result = client_send_msg(fd, &message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
-   client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   result = client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -174,8 +222,10 @@ int send_orig_path_request(int fd, const char *path, char *newpath)
    ldcs_message_t message;
    char buffer[MAX_PATH_LEN+1];
    buffer[MAX_PATH_LEN] = '\0';
-   int path_len = strlen(path)+1;
-    
+   int path_len = strlen(path)+1, result;
+
+   if (client_is_disconnected()) return DISCONNECT;
+
    if (path_len > MAX_PATH_LEN) {
       err_printf("Path to long for message");
       return -1;
@@ -186,13 +236,21 @@ int send_orig_path_request(int fd, const char *path, char *newpath)
    message.header.len = strlen(path) + 1;
    message.data = (void *) buffer;
 
-   debug_printf3("Sending message of type: file_orig_path len=%lu, data=%s\n",
+   debug_printf3("Sending message of type: file_orig_path len=%d, data=%s\n",
                  message.header.len, path);
    COMM_LOCK;
 
-   client_send_msg(fd, &message);
+   result = client_send_msg(fd, &message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
-   client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   result = client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -208,17 +266,29 @@ int send_orig_path_request(int fd, const char *path, char *newpath)
 int send_dirlists_request(int fd, char **local_result, char **exece_result, char **to_free)
 {
    ldcs_message_t message;
-   int local_len, ee_len;
+   int local_len, ee_len, result;
    char *buffer;
    int buffer_pos = 0;
+
+   if (client_is_disconnected()) return DISCONNECT;
    
    message.header.type = LDCS_MSG_DIRLISTS_REQ;
    message.header.len = 0;
 
    debug_printf3("Sending message of type: localprefix_req\n");
    COMM_LOCK;
-   client_send_msg(fd, &message);
-   client_recv_msg_dynamic(fd, &message, LDCS_READ_BLOCK);
+   result = client_send_msg(fd, &message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
+
+   result = client_recv_msg_dynamic(fd, &message, LDCS_READ_BLOCK);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
+
    COMM_UNLOCK;
 
    buffer = (char *) message.data;
@@ -241,7 +311,10 @@ int send_dirlists_request(int fd, char **local_result, char **exece_result, char
 
 int send_dir_cwd(int fd, char *cwd)
 {
+   int result;
    ldcs_message_t message;
+
+   if (client_is_disconnected()) return DISCONNECT;
 
    message.header.type = LDCS_MSG_CWD;
    message.header.len = strlen(cwd) + 1;
@@ -249,7 +322,11 @@ int send_dir_cwd(int fd, char *cwd)
 
    COMM_LOCK;
 
-   client_send_msg(fd, &message);
+   result = client_send_msg(fd, &message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -258,14 +335,21 @@ int send_dir_cwd(int fd, char *cwd)
 
 int send_cwd(int fd)
 {
+   int result;
    char buffer[MAX_PATH_LEN+1];
    buffer[MAX_PATH_LEN] = '\0';
+
+   if (client_is_disconnected()) return DISCONNECT;
 
    if (!getcwd(buffer, MAX_PATH_LEN)) {
       return -1;
    }
 
-   send_dir_cwd(fd, buffer);
+   result = send_dir_cwd(fd, buffer);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    return 0;
 }
@@ -273,7 +357,9 @@ int send_cwd(int fd)
 int send_pid(int fd) {
    ldcs_message_t message;
    char buffer[16];
-   int rc=0;
+   int rc=0, result;
+
+   if (client_is_disconnected()) return DISCONNECT;
 
    snprintf(buffer, 16, "%d", getpid());
    message.header.type = LDCS_MSG_PID;
@@ -284,7 +370,11 @@ int send_pid(int fd) {
 
    COMM_LOCK;
 
-   client_send_msg(fd,&message);
+   result = client_send_msg(fd,&message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -294,7 +384,9 @@ int send_pid(int fd) {
 int send_cpu(int fd, int cpu) {
    ldcs_message_t message;
    char buffer[16];
-   int rc=0;
+   int rc=0, result;
+
+   if (client_is_disconnected()) return DISCONNECT;
 
    snprintf(buffer, 16, "%d", cpu);
    message.header.type = LDCS_MSG_CPU;
@@ -305,7 +397,11 @@ int send_cpu(int fd, int cpu) {
 
    COMM_LOCK;
 
-   client_send_msg(fd, &message);
+   result = client_send_msg(fd, &message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -314,6 +410,9 @@ int send_cpu(int fd, int cpu) {
 
 int send_location(int fd, char *location) {
    ldcs_message_t message;
+   int result;
+
+   if (client_is_disconnected()) return DISCONNECT;
 
    message.header.type = LDCS_MSG_LOCATION;
    message.header.len = strlen(location)+1;
@@ -323,7 +422,11 @@ int send_location(int fd, char *location) {
 
    COMM_LOCK;
 
-   client_send_msg(fd,&message);
+   result = client_send_msg(fd,&message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -333,15 +436,29 @@ int send_location(int fd, char *location) {
 int send_ldso_info_request(int fd, const char *ldso_path, char *result_path)
 {
    ldcs_message_t message;
+   int result;
+
+   if (client_is_disconnected()) return DISCONNECT;
 
    message.header.type = LDCS_MSG_LOADER_DATA_REQ;
    message.header.len = strlen(ldso_path)+2;
    message.data = (void *) ldso_path;
    
    COMM_LOCK;
-   client_send_msg(fd, &message);
+   result = client_send_msg(fd, &message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
+
    message.data = result_path;
-   client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+
+   result = client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
+
    COMM_UNLOCK;
 
    if (message.header.type != LDCS_MSG_LOADER_DATA_RESP) {
@@ -354,13 +471,27 @@ int send_ldso_info_request(int fd, const char *ldso_path, char *result_path)
 int get_python_prefix(int fd, char **prefix)
 {
    ldcs_message_t message;
+   int result;
+
+   if (client_is_disconnected()) return DISCONNECT;
+
    message.header.type = LDCS_MSG_PYTHONPREFIX_REQ;
    message.header.len = 0;
    message.data = NULL;
       
    COMM_LOCK;
-   client_send_msg(fd, &message);
-   client_recv_msg_dynamic(fd, &message, LDCS_READ_BLOCK);
+   result = client_send_msg(fd, &message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
+
+   result = client_recv_msg_dynamic(fd, &message, LDCS_READ_BLOCK);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
+
    COMM_UNLOCK;
    *prefix = (char *) message.data;
    return 0;
@@ -369,7 +500,9 @@ int get_python_prefix(int fd, char **prefix)
 int send_rankinfo_query(int fd, int *mylrank, int *mylsize, int *mymdrank, int *mymdsize) {
    ldcs_message_t message;
    char buffer[MAX_PATH_LEN];
-   int *p;
+   int *p, result;
+
+   if (client_is_disconnected()) return DISCONNECT;
 
    debug_printf3("Sending rankinfo query\n");
 
@@ -379,9 +512,17 @@ int send_rankinfo_query(int fd, int *mylrank, int *mylsize, int *mymdrank, int *
 
    COMM_LOCK;
 
-   client_send_msg(fd,&message);
+   result = client_send_msg(fd,&message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
-   client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   result = client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -405,6 +546,9 @@ int send_procmaps_query(int fd, int pid, char *result)
 {
    ldcs_message_t message;
    char buffer[MAX_PATH_LEN+1];
+   int iresult;
+
+   if (client_is_disconnected()) return DISCONNECT;
 
    debug_printf3("Sending procmaps query\n");
 
@@ -415,9 +559,17 @@ int send_procmaps_query(int fd, int pid, char *result)
 
    COMM_LOCK;
 
-   client_send_msg(fd, &message);
+   iresult = client_send_msg(fd, &message);
+   if (iresult == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
-   client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   iresult = client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   if (iresult == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -436,6 +588,9 @@ int send_pickone_query(int fd, char *key, int *result)
 {
    ldcs_message_t message;
    char buffer[MAX_PATH_LEN+1];
+   int iresult;
+
+   if (client_is_disconnected()) return DISCONNECT;
 
    debug_printf3("Sending pickone query\n");
 
@@ -447,8 +602,17 @@ int send_pickone_query(int fd, char *key, int *result)
 
    COMM_LOCK;
 
-   client_send_msg(fd, &message);
-   client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   iresult = client_send_msg(fd, &message);
+   if (iresult == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
+
+   iresult = client_recv_msg_static(fd, &message, LDCS_READ_BLOCK);
+   if (iresult == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
 
    COMM_UNLOCK;
 
@@ -464,6 +628,9 @@ int send_pickone_query(int fd, char *key, int *result)
 
 int send_end(int fd) {
    ldcs_message_t message;
+   int result;
+
+   if (client_is_disconnected()) return DISCONNECT;
    
    message.header.type = LDCS_MSG_END;
    message.header.len = 0;
@@ -471,7 +638,11 @@ int send_end(int fd) {
    
    COMM_LOCK;
    
-   client_send_msg(fd, &message);
+   result = client_send_msg(fd, &message);
+   if (result == -1) {
+      COMM_UNLOCK;
+      return bad_comm(fd);
+   }
    
    COMM_UNLOCK;
    

--- a/src/client/client_comlib/client_api.h
+++ b/src/client/client_comlib/client_api.h
@@ -23,36 +23,43 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+//Possible return value from any client_* or send_* call.
+#define DISCONNECT -2
+
+int client_is_disconnected();
+
+#define WARN_UNUSED __attribute__((warn_unused_result))
+
 /**
  * Communication functions for sending messages to the server
  **/
-int send_file_query(int fd, char* path, int dso, char **newpath, int *errcode);
-int send_dir_cwd(int fd, char *cwd);
-int send_cwd(int fd);
+int send_file_query(int fd, char* path, int dso, char **newpath, int *errcode) WARN_UNUSED;
+int send_dir_cwd(int fd, char *cwd) WARN_UNUSED;
+int send_cwd(int fd) WARN_UNUSED;
 int send_pid(int fd);
 int send_cpu(int fd, int cpu);
 int send_location(int fd, char *location);
 int send_rankinfo_query(int fd, int *mylrank, int *mylsize, int *mymdrank, int *mymdsize);
 int send_end(int fd);
-int send_existance_test(int fd, char *path, int *exists);
+int send_existance_test(int fd, char *path, int *exists) WARN_UNUSED;
 #define STAT_SELF 1
-int send_stat_request(int fd, char *path, int islstat, char *result);
-int send_ldso_info_request(int fd, const char *ldso_path, char *result_path);
-int send_orig_path_request(int fd, const char *path, char *newpath);
-int send_dirlists_request(int fd, char **local_result, char **exece_result, char **to_free);
-int send_procmaps_query(int fd, int pid, char *result);
-int send_pickone_query(int fd, char *key, int *result);
+int send_stat_request(int fd, char *path, int islstat, char *result) WARN_UNUSED;
+int send_ldso_info_request(int fd, const char *ldso_path, char *result_path) WARN_UNUSED;
+int send_orig_path_request(int fd, const char *path, char *newpath) WARN_UNUSED;
+int send_dirlists_request(int fd, char **local_result, char **exece_result, char **to_free) WARN_UNUSED;
+int send_procmaps_query(int fd, int pid, char *result) WARN_UNUSED;
+int send_pickone_query(int fd, char *key, int *result) WARN_UNUSED;
 
-int get_python_prefix(int fd, char **prefix);
+int get_python_prefix(int fd, char **prefix) WARN_UNUSED;
 
 /* client */
-int client_open_connection(char* location, number_t number);
+int client_open_connection(char* location, number_t number) WARN_UNUSED;
 int client_close_connection(int connid);
 int client_register_connection(char *connection_str);
 char *client_get_connection_string(int fd);
-int client_send_msg(int connid, ldcs_message_t * msg);
-int client_recv_msg_static(int fd, ldcs_message_t *msg, ldcs_read_block_t block);
-int client_recv_msg_dynamic(int fd, ldcs_message_t *msg, ldcs_read_block_t block);
+int client_send_msg(int connid, ldcs_message_t * msg) WARN_UNUSED;
+int client_recv_msg_static(int fd, ldcs_message_t *msg, ldcs_read_block_t block) WARN_UNUSED;
+int client_recv_msg_dynamic(int fd, ldcs_message_t *msg, ldcs_read_block_t block) WARN_UNUSED;
 int is_client_fd(int connfd, int fd);
 
 #endif

--- a/src/server/comlib/ldcs_api_listen.c
+++ b/src/server/comlib/ldcs_api_listen.c
@@ -20,6 +20,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <string.h>
 #include <sys/inotify.h>
 #include <errno.h>
+#include <assert.h>
 
 #include "ldcs_api.h"
 
@@ -139,6 +140,7 @@ int ldcs_listen() {
 
    debug_printf2("Listening for data\n");
    do_listen=(ldcs_listen_data.item_table_used>0);
+assert(0);
    while(do_listen && !do_exit) {
       nfds = 0;
       FD_ZERO(&rd);

--- a/src/server/startup/spindle_be.cc
+++ b/src/server/startup/spindle_be.cc
@@ -120,7 +120,6 @@ int spindleRunBE(unsigned int port, unsigned int num_ports, unique_id_t unique_i
 {
    int result;
    spindle_args_t args;
-
    LOGGING_INIT(const_cast<char *>("Server"));
 
    initSecurity(security_type, unique_id);


### PR DESCRIPTION
Addresses #114.

In failure cases where the client can determine a disconnect occurred, it should fall back to non-Spindle operation and continue.

Code copied from Matt's earlier resilience work.