### PR TITLE
Slurm testsuite in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: ci-${{github.ref}}-${{github.event.pull_request.number || github.run_number}}
@@ -102,5 +103,63 @@ jobs:
         continue-on-error: true
         run: |
           cd containers/spindle-flux-ubuntu
+          docker compose down
+
+  spindle-slurm-ubuntu:
+    name: Testsuite (Slurm, Ubuntu)
+    environment: Spindle CI
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out Spindle
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
+
+      - name: Setup Docker Compose
+        uses: docker/setup-compose-action@364cc21a5de5b1ee4a7f5f9d3fa374ce0ccde746
+        with:
+          version: latest
+
+      - name: Login to GitHub Container Registry
+        if: ${{ !env.ACT }}
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate MariaDB configuration
+        id: slurm-ubuntu-mariadb
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing
+          ./generate_config.sh
+
+      - name: Build spindle-slurm-ubuntu image
+        id: slurm-ubuntu-build
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing
+          docker compose --progress=plain build
+
+      - name: Bring spindle-slurm-ubuntu up
+        id: slurm-ubuntu-up
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing
+          docker compose up -d --wait --wait-timeout 120
+
+      - name: Verify munge works in spindle-slurm-ubuntu
+        id: slurm-ubuntu-munge
+        run: |
+          docker exec slurm-head bash -c 'munge -n | unmunge'
+
+      - name: Run spindle-slurm-ubuntu testsuite
+        id: slurm-ubuntu-testsuite
+        run: |
+          docker exec slurm-head bash -c 'cd Spindle-build/testsuite && salloc -n${workers} -N${workers} ./runTests ${workers}'
+
+      - name: Bring spindle-slurm-ubuntu down
+        id: slurm-ubuntu-down
+        if: ${{ always() }}
+        continue-on-error: true
+        run: |
+          cd containers/spindle-slurm-ubuntu/testing
           docker compose down
 

--- a/containers/spindle-slurm-ubuntu/testing/Dockerfile
+++ b/containers/spindle-slurm-ubuntu/testing/Dockerfile
@@ -1,0 +1,39 @@
+ARG BASE_VERSION=latest
+FROM ghcr.io/llnl/spindle-slurm-base:${BASE_VERSION}
+ARG replicas=4
+ENV workers=${replicas}
+
+ARG BUILD_ROOT=containers/spindle-slurm-ubuntu/testing
+
+# Slurm daemons run as $SLURM_USER
+ARG SLURM_USER=slurm
+
+# Applications run as $USER
+ARG USER=slurmuser
+ARG UID=1001
+
+# Set up the Slurm install already present in the base image
+COPY ${BUILD_ROOT}/scripts/setup_slurm.sh /setup_slurm.sh
+COPY ${BUILD_ROOT}/conf/slurm.conf /home/${SLURM_USER}/slurm.conf
+COPY ${BUILD_ROOT}/conf/slurmdbd.conf /home/${SLURM_USER}/slurmdbd.conf
+COPY ${BUILD_ROOT}/conf/cgroup.conf /home/${SLURM_USER}/cgroup.conf
+RUN /setup_slurm.sh
+
+# Slurm without Spank plugin needs passwordless ssh
+USER ${USER}
+WORKDIR /home/${USER}
+COPY ${BUILD_ROOT}/conf/ssh_config /home/${USER}/
+COPY ${BUILD_ROOT}/scripts/setup_ssh.sh /home/${USER}/
+RUN /home/${USER}/setup_ssh.sh
+
+# Copy the Spindle repo into the container and build it
+RUN mkdir -p /home/${USER}/Spindle
+COPY . /home/${USER}/Spindle
+COPY ${BUILD_ROOT}/scripts/build_spindle.sh /home/${USER}/build_spindle.sh
+RUN ./build_spindle.sh
+
+COPY ${BUILD_ROOT}/scripts/entrypoint.sh /home/${USER}/entrypoint.sh
+ENV PATH /home/${USER}/Spindle-inst/bin:$PATH
+
+ENTRYPOINT /bin/bash ./entrypoint.sh
+

--- a/containers/spindle-slurm-ubuntu/testing/conf/cgroup.conf
+++ b/containers/spindle-slurm-ubuntu/testing/conf/cgroup.conf
@@ -1,0 +1,1 @@
+CgroupPlugin=cgroup/v1

--- a/containers/spindle-slurm-ubuntu/testing/conf/slurm.conf
+++ b/containers/spindle-slurm-ubuntu/testing/conf/slurm.conf
@@ -1,0 +1,42 @@
+ClusterName=linux
+ControlMachine=slurm-head
+ControlAddr=slurm-head
+SlurmUser=slurm
+SlurmctldPort=6817
+SlurmdPort=6818
+AuthType=auth/munge
+StateSaveLocation=/var/lib/slurmd
+SlurmdSpoolDir=/var/spool/slurmd
+SwitchType=switch/none
+MpiDefault=none
+SlurmctldPidFile=/var/run/slurmd/slurmctld.pid
+SlurmdPidFile=/var/run/slurmd/slurmd.pid
+ProctrackType=proctrack/linuxproc
+TaskPlugin=task/affinity
+ReturnToService=2
+SlurmctldTimeout=300
+SlurmdTimeout=300
+InactiveLimit=0
+MinJobAge=300
+KillWait=30
+Waittime=0
+SchedulerType=sched/backfill
+SelectType=select/cons_tres
+SelectTypeParameters=CR_Core_Memory
+SlurmctldDebug=3
+SlurmctldLogFile=/var/log/slurm/slurmctld.log
+SlurmdDebug=3
+SlurmdLogFile=/var/log/slurm/slurmd.log
+JobCompType=jobcomp/filetxt
+JobCompLoc=/var/log/slurm/jobcomp.log
+JobAcctGatherType=jobacct_gather/linux
+JobAcctGatherFrequency=30
+AccountingStorageType=accounting_storage/slurmdbd
+AccountingStorageHost=slurm-db
+AccountingStoragePort=6819
+NodeName=slurm-node-1 NodeAddr=slurm-node-1 CPUs=3 RealMemory=1000 State=UNKNOWN
+NodeName=slurm-node-2 NodeAddr=slurm-node-2 CPUs=3 RealMemory=1000 State=UNKNOWN
+NodeName=slurm-node-3 NodeAddr=slurm-node-3 CPUs=3 RealMemory=1000 State=UNKNOWN
+NodeName=slurm-node-4 NodeAddr=slurm-node-4 CPUs=3 RealMemory=1000 State=UNKNOWN
+PartitionName=debug Nodes=ALL Default=YES MaxTime=INFINITE State=UP
+

--- a/containers/spindle-slurm-ubuntu/testing/conf/slurmdbd.conf.template
+++ b/containers/spindle-slurm-ubuntu/testing/conf/slurmdbd.conf.template
@@ -1,0 +1,10 @@
+AuthType=auth/munge
+DbdAddr=slurm-db
+DbdHost=slurm-db
+SlurmUser=slurm
+DebugLevel=4
+LogFile=/var/log/slurm/slurmdbd.log
+PidFile=/var/run/slurmdbd/slurmdbd.pid
+StorageType=accounting_storage/mysql
+StorageHost=slurm-mariadb
+StorageUser=slurm

--- a/containers/spindle-slurm-ubuntu/testing/conf/ssh_config
+++ b/containers/spindle-slurm-ubuntu/testing/conf/ssh_config
@@ -1,0 +1,3 @@
+Host slurm-*
+    StrictHostKeyChecking no
+

--- a/containers/spindle-slurm-ubuntu/testing/docker-compose.yml
+++ b/containers/spindle-slurm-ubuntu/testing/docker-compose.yml
@@ -1,0 +1,126 @@
+# `replicas` must match the number of nodes defined in the services section
+x-shared-workers:
+  &workers
+  replicas: 4 
+
+# Base image version to use
+x-shared-build-args: &shared-build-args
+  BASE_VERSION: latest
+  <<: *workers
+
+# Docker prohibits copying files from outside of the build context.
+# In order to be able to copy the whole repo into the container,
+# we have to set the context to be the root of the repo.
+# We then have to specify the path from there to the Dockerfile.
+x-shared-build-context: &shared-build-context
+  context: ../../..
+  dockerfile: containers/spindle-slurm-ubuntu/testing/Dockerfile
+  args: *shared-build-args
+
+# Name of the head node
+x-shared-environment: &shared-environment
+  SLURM_HEAD_NODE: slurm-head
+  <<: *workers
+
+# The entrypoint runs different services depending
+# on the node's role. Valid options are:
+#   - worker: runs slurmd
+#   - db:     runs slurmdbd
+#   - ctl:    runs slurmctld
+x-worker-environment: &worker-environment
+  SLURM_ROLE: worker
+  <<: *shared-environment
+
+networks:
+  slurm:
+    driver: bridge
+
+# Common parameters for all nodes.
+x-shared-node-parameters: &shared-node-parameters
+  build: *shared-build-context
+  networks:
+    - slurm
+  cap_add:
+    - SYS_NICE # Required for libnuma
+
+x-healthcheck-parameters: &healthcheck-parameters
+  start_period: 3s
+  interval: 3s
+  timeout: 5s
+  retries: 5
+
+x-worker-parameters: &worker-node-parameters
+  <<: *shared-node-parameters
+  environment: *worker-environment
+  depends_on:
+    slurm-head:
+      condition: service_healthy
+  healthcheck:
+    test: ["CMD", "stat", "/var/run/slurmd/slurmd.pid"]
+    <<: *healthcheck-parameters
+
+services:
+  slurm-mariadb:
+    image: mariadb:12
+    networks:
+      - slurm
+    hostname: slurm-mariadb
+    container_name: slurm-mariadb
+    env_file: mariadb.env
+    environment:
+      MYSQL_RANDOM_ROOT_PASSWORD: "yes"
+      MYSQL_DATABASE: "slurm_acct_db"
+      MYSQL_USER: "slurm"
+    healthcheck:
+      test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
+      <<: *healthcheck-parameters
+
+  slurm-db:
+    <<: *shared-node-parameters
+    hostname: slurm-db
+    container_name: slurm-db
+    environment:
+      SLURM_ROLE: db
+      <<: *shared-environment
+    depends_on:
+      slurm-mariadb:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "stat", "/var/run/slurmdbd/slurmdbd.pid"]
+      <<: *healthcheck-parameters
+
+  slurm-head:
+    <<: *shared-node-parameters
+    hostname: slurm-head
+    container_name: slurm-head
+    tty: true
+    environment:
+      SLURM_ROLE: ctl
+      <<: *shared-environment
+    depends_on:
+      slurm-db:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "stat", "/var/run/slurmd/slurmctld.pid"]
+      <<: *healthcheck-parameters
+
+  slurm-node-1:
+    <<: *worker-node-parameters
+    hostname: slurm-node-1
+    container_name: slurm-node-1
+
+  slurm-node-2:
+    <<: *worker-node-parameters
+    hostname: slurm-node-2
+    container_name: slurm-node-2
+
+  slurm-node-3:
+    <<: *worker-node-parameters
+    hostname: slurm-node-3
+    container_name: slurm-node-3
+
+  slurm-node-4:
+    <<: *worker-node-parameters
+    hostname: slurm-node-4
+    container_name: slurm-node-4
+

--- a/containers/spindle-slurm-ubuntu/testing/generate_config.sh
+++ b/containers/spindle-slurm-ubuntu/testing/generate_config.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Generate random password for the MariaDB slurm user
+# and set it in config files
+
+MARIADB_PASS=$(openssl rand --base64 16 | head -c -3)
+echo "MARIADB_PASSWORD: \"${MARIADB_PASS}\"" > mariadb.env
+cp conf/slurmdbd.conf.template conf/slurmdbd.conf
+echo "StoragePass=${MARIADB_PASS}" >> conf/slurmdbd.conf
+

--- a/containers/spindle-slurm-ubuntu/testing/scripts/add_docker_user.sh
+++ b/containers/spindle-slurm-ubuntu/testing/scripts/add_docker_user.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+sudo groupadd -g ${UID} ${USER}
+sudo useradd -g ${USER} -u ${UID} -d /home/${USER} -m ${USER}
+# Allow user to run as other users so that munge can be started as the munge user
+sudo sh -c "printf \"${USER} ALL=(ALL) NOPASSWD: ALL\\n\" >> /etc/sudoers"
+sudo adduser ${USER} sudo
+sudo usermod -s /bin/bash ${USER}
+

--- a/containers/spindle-slurm-ubuntu/testing/scripts/build_spindle.sh
+++ b/containers/spindle-slurm-ubuntu/testing/scripts/build_spindle.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+mkdir -p /home/${USER}/Spindle-build
+cd /home/${USER}/Spindle-build
+/home/${USER}/Spindle/configure --prefix=/home/${USER}/Spindle-inst --enable-sec-munge --with-rm=slurm --with-rsh-launch --with-rsh-cmd=/usr/bin/ssh --with-localstorage=/tmp CFLAGS="-O2 -g" CXXFLAGS="-O2 -g"
+make -j$(nproc)
+make install
+

--- a/containers/spindle-slurm-ubuntu/testing/scripts/entrypoint.sh
+++ b/containers/spindle-slurm-ubuntu/testing/scripts/entrypoint.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+echo "SLURM_ROLE: ${SLURM_ROLE}"
+
+echo "Starting sshd..."
+sudo service ssh start
+echo "Starting munged..."
+sudo -u munge /usr/sbin/munged 
+
+if [ "${SLURM_ROLE}" = "db" ]; then
+    echo "Starting slurmdbd..."
+    sudo -u slurm /usr/sbin/slurmdbd -Dvvv
+elif [ "${SLURM_ROLE}" = "ctl" ] ; then
+    echo "Starting slurmctld..."
+    sudo -u slurm /usr/sbin/slurmctld -i -Dvvv
+elif [ "${SLURM_ROLE}" = "worker" ] ; then
+    echo "Starting slurmd..."
+    sudo /usr/sbin/slurmd -Dvvv
+fi
+
+sleep inf

--- a/containers/spindle-slurm-ubuntu/testing/scripts/setup_slurm.sh
+++ b/containers/spindle-slurm-ubuntu/testing/scripts/setup_slurm.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+mkdir -p /etc/slurm /etc/sysconfig/slurm /var/spool/slurmd /var/spool/slurmctld /var/run/slurmd /var/run/slurmdbd /var/lib/slurmd /var/log/slurm
+touch /var/lib/slurmd/node_state /var/lib/slurmd/front_end_state /var/lib/slurmd/job_state /var/lib/slurmd/resv_state /var/lib/slurmd/trigger_state /var/lib/slurmd/assoc_mgr_state /var/lib/slurmd/assoc_usage /var/lib/slurmd/qos_usage /var/lib/slurmd/fed_mgr_state 
+cp /home/${SLURM_USER}/slurm.conf /etc/slurm/slurm.conf
+cp /home/${SLURM_USER}/slurmdbd.conf /etc/slurm/slurmdbd.conf
+cp /home/${SLURM_USER}/cgroup.conf /etc/slurm/cgroup.conf
+chown -R slurm:slurm /etc/slurm /etc/sysconfig/slurm /var/spool/slurmd /var/spool/slurmctld /var/run/slurmd /var/run/slurmdbd /var/lib/slurmd /var/log/slurm 
+chmod 600 /etc/slurm/slurmdbd.conf

--- a/containers/spindle-slurm-ubuntu/testing/scripts/setup_ssh.sh
+++ b/containers/spindle-slurm-ubuntu/testing/scripts/setup_ssh.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+# Sets up passwordless ssh between nodes as required for
+# Spindle using --with-rsh-launch
+ssh-keygen -t ed25519 -f /home/${USER}/.ssh/id_ed25519 -N "" -q
+cp /home/${USER}/.ssh/id_ed25519.pub /home/${USER}/.ssh/authorized_keys
+chmod 600 /home/${USER}/.ssh/authorized_keys
+cp /home/${USER}/ssh_config /home/${USER}/.ssh/config
+chmod 600 /home/${USER}/.ssh/config
+rm -f /home/${USER}/ssh_config

--- a/testsuite/run_driver_slurm
+++ b/testsuite/run_driver_slurm
@@ -11,7 +11,7 @@ PROCS=$SPINDLE_TEST_ARGS
 fi
 export PROCS
 
-if [ "x$SPINDLE_BGQ_LD_PRELOAD" == "xtrue" ] ; then
+if [ "x$SPINDLE_BGQ_LD_PRELOAD" = "xtrue" ] ; then
 PRELOAD_ARGS="--runjob-opts=--envs LD_PRELOAD=$LIBRARY_LIST"
 elif [ "x$SPINDLE_LD_PRELOAD" != "x" ] ; then
 export LD_PRELOAD=$SPINDLE_LD_PRELOAD    


### PR DESCRIPTION
This is the second of two PRs to enable running the Spindle testsuite in CI with on a Slurm cluster.

Using the base image created by the workflow from the previous PR, #113, this derives an image with Slurm configured and sets up a 4-node Slurm cluster using Docker Compose. The steps in creating the image are:
- Configure MariaDB with a random password and configure slurmdbd with that password.
- Configure a Slurm cluster with a single partition of 4 nodes.
- Generate an SSH key and set up authorized_keys to allow passwordless ssh between nodes.
- Disable SSH strict host key checking so SSH fingerprint doesn't require `yes` input. 
- Build Spindle with Slurm support.

An additional job is added to the CI workflow to bring up the Slurm cluster and run the testsuite in it.

The only change to existing Spindle code is to `run_driver_slurm`. It specifies `#!/bin/sh`, but used `==` for comparison, which is a bash extension. This is fixed by using `=` instead.