### PR TITLE
Fixes/updates for compilation under gcc 15.1.0 -Wall -Wextra -Werror 

### DIFF
--- a/scripts/remap.sh
+++ b/scripts/remap.sh
@@ -19,6 +19,9 @@ cat <<EOF | $CCLINE -I $SRCDIR -shared -DWORKINGDIR=\"$WORKINGDIR\" -DUNIQ=\"$UN
 
 void get_relocated_file(int ldcs_id, char *orig_exec, int dso, char **reloc_exec, int *errcode, int *direxists)
 {
+   (void)ldcs_id;
+   (void)orig_exec;
+   (void)dso;
    *reloc_exec = strdup(WORKINGDIR "/remap2" UNIQ);
    *errcode = 0;
    if (direxists) *direxists = 1;
@@ -44,6 +47,8 @@ extern int dowork();
 int data = 5;
 int main(int argc, char *argv[])
 {
+   (void)argc;
+   (void)argv;
    return dowork();
 }
 EOF

--- a/src/biter/biterc.c
+++ b/src/biter/biterc.c
@@ -76,12 +76,12 @@ static int init_locks(biterc_session_t *session)
 {
    shminfo_t *shm = session->shm;
    biter_header_t *header = &shm->shared_header->biter;
-   session->pipe_lock.lock = header->locks + 0;
-   session->pipe_lock.held_by = header->locks + 1;
-   session->queue_lock.lock = header->locks + 2;
-   session->queue_lock.held_by = header->locks + 3;
-   session->write_lock.lock = header->locks + 4;
-   session->write_lock.held_by = header->locks + 5;
+   session->pipe_lock.lock = header->lock + 0;
+   session->pipe_lock.held_by = header->held_by + 0;
+   session->queue_lock.lock = header->lock + 1;
+   session->queue_lock.held_by = header->held_by + 1;
+   session->write_lock.lock = header->lock + 2;
+   session->write_lock.held_by = header->held_by + 2;
    return init_heap_lock(shm);
 }
 

--- a/src/biter/biterc.c
+++ b/src/biter/biterc.c
@@ -32,6 +32,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "spindle_debug.h"
 #include "shmutil.h"
+#include "ccwarns.h"
 
 #if !defined(MAX_PATH_LEN)
 #define MAX_PATH_LEN 4096
@@ -76,12 +77,17 @@ static int init_locks(biterc_session_t *session)
 {
    shminfo_t *shm = session->shm;
    biter_header_t *header = &shm->shared_header->biter;
-   session->pipe_lock.lock = header->lock + 0;
-   session->pipe_lock.held_by = header->held_by + 0;
-   session->queue_lock.lock = header->lock + 1;
-   session->queue_lock.held_by = header->held_by + 1;
-   session->write_lock.lock = header->lock + 2;
-   session->write_lock.held_by = header->held_by + 2;
+   session->pipe_lock.lock = header->locks + 0;
+   session->queue_lock.lock = header->locks + 2;
+   session->write_lock.lock = header->locks + 4;
+
+   GCC_DISABLE_WARNING("-Wincompatible-pointer-types")
+   // unsigned long int * assigned to volatile pid_t *
+   session->pipe_lock.held_by = header->locks + 1;
+   session->queue_lock.held_by = header->locks + 3;
+   session->write_lock.held_by = header->locks + 5;
+   GCC_ENABLE_WARNING
+
    return init_heap_lock(shm);
 }
 

--- a/src/biter/biterd.c
+++ b/src/biter/biterd.c
@@ -44,8 +44,8 @@ typedef struct biterd_session {
    int s2c_fd;
    char *c2s_path;
    char *s2c_path;
-   int num_clients;
-   int clients_accepted;
+   uint32_t num_clients;
+   uint32_t clients_accepted;
    void *proc_messages;
    msg_header_t polled_data;
    int has_polled_data;
@@ -55,7 +55,7 @@ typedef struct biterd_session {
 } biterd_session_t;
 
 static biterd_session_t sessions[BITER_MAX_SESSIONS];
-static int max_session = 0;
+static uint32_t max_session = 0;
 
 extern void init_queue(int num_procs, void *session);
 
@@ -117,7 +117,7 @@ int biterd_newsession(const char *tmpdir, int cn_id)
    char *c2s_path = NULL, *s2c_path = NULL;
    int result, c2s_fd = -1, s2c_fd = -1;
    int path_len = strlen(tmpdir) + 32;
-   int session_id, i, unique_number, num_clients;
+   uint32_t session_id, i, unique_number, num_clients;
 
    assert(sizeof(int) == sizeof(uint32_t)); //Fix FD_* macros if this fails on new platform
 
@@ -393,7 +393,7 @@ int biterd_has_data_avail(int session_id, fd_set *readset)
    int client_id;
    int fd = sessions[session_id].c2s_fd;
    int aux_fd = get_aux_fd();
-   int i, orig;
+   uint32_t i, orig;
 
    session = sessions + session_id;
 
@@ -422,8 +422,8 @@ int biterd_has_data_avail(int session_id, fd_set *readset)
 
 int biterd_get_session_proc_w_aux_data(int *session_result, int *proc_result)
 {
-   static int last_session = 0;
-   int cur_session, start_session, j;
+   static uint32_t last_session = 0;
+   uint32_t cur_session, start_session, j;
    biterd_session_t *session;
    cur_session = start_session = last_session;
 

--- a/src/biter/client_queue.c
+++ b/src/biter/client_queue.c
@@ -91,6 +91,7 @@ int init_message(int num_procs, void *header_ptr, void *session)
 
 void get_message(int for_proc, void **msg_data, size_t *msg_size, size_t *bytes_read, void *session)
 {
+   (void)session;
    message_t *msg;
    sheep_ptr_t *msgp = proc_messages + for_proc;
    assert(!IS_SHEEP_NULL(msgp));
@@ -103,6 +104,7 @@ void get_message(int for_proc, void **msg_data, size_t *msg_size, size_t *bytes_
 
 int has_message(int for_proc, void *session)
 {
+   (void)session;
    sheep_ptr_t *msgp = proc_messages + for_proc;
    return !IS_SHEEP_NULL(msgp);
 }
@@ -209,6 +211,7 @@ int get_message_space(size_t msg_size, unsigned char **msg_space, void **header_
 
 void update_bytes_read(int for_proc, size_t newval, void *session)
 {
+   (void)session;
    message_t *msg;
    sheep_ptr_t *msgp = proc_messages + for_proc;
    assert(!IS_SHEEP_NULL(msgp));

--- a/src/biter/demultiplex.h
+++ b/src/biter/demultiplex.h
@@ -22,7 +22,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 typedef struct msg_header_t {
    uint32_t msg_size;
-   uint32_t msg_target;
+   int msg_target;
 } msg_header_t;
 
 extern int test_pipe_lock(void *session);

--- a/src/biter/ids.h
+++ b/src/biter/ids.h
@@ -18,6 +18,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #define IDS_H_
 
 int biterc_get_job_id();
-unsigned int biterc_get_rank();
+unsigned int biterc_get_rank(int session_id);
 
 #endif

--- a/src/biter/linux_daemon_ids.c
+++ b/src/biter/linux_daemon_ids.c
@@ -25,6 +25,7 @@ int biterd_num_compute_nodes()
 
 int biterd_ranks_in_cn(int cn_id)
 {
+   (void)cn_id;
    char *proc_s = getenv("PROCS");
    if (proc_s)
       return atoi(proc_s);
@@ -34,20 +35,26 @@ int biterd_ranks_in_cn(int cn_id)
 
 int biterd_unique_num_for_cn(int cn_id)
 {
+   (void)cn_id;
    return 0;
 }
 
 int biterd_get_rank(int compute_node_id, int client_id)
 {
+   (void)compute_node_id;
    return client_id;
 }
 
 int biterd_register_rank(int session_id, uint32_t client_id, uint32_t rank)
 {
+   (void)session_id;
+   (void)client_id;
+   (void)rank;
    return 0;
 }
 
 int biterd_init_comms(const char *tmpdir)
 {
+   (void)tmpdir;
    return 0;
 }

--- a/src/biter/server_queue.c
+++ b/src/biter/server_queue.c
@@ -45,36 +45,43 @@ void init_queue(int num_procs, void *session)
 
 int test_pipe_lock(void *session)
 {
+   (void)session;
    return 1;
 }
 
 int release_pipe_lock(void *session)
 {
+   (void)session;
    return 0;
 }
 
 int take_queue_lock(void *session)
 {
+   (void)session;
    return 0;
 }
 
 int release_queue_lock(void *session)
 {
+   (void)session;
    return 0;
 }
 
 int take_write_lock(void *session)
 {
+   (void)session;
    return 0;
 }
 
 int release_write_lock(void *session)
 {
+   (void)session;
    return 0;
 }
 
 int take_pipe_lock(void *session)
 {
+   (void)session;
    return 0;
 }
 
@@ -124,6 +131,7 @@ int enqueue_message(int for_proc, void *msg_data, size_t msg_size, void *header_
 
 int get_message_space(size_t msg_size, unsigned char **msg_space, void **header_space, void *session)
 {
+   (void)session;
    *msg_space = (unsigned char *) malloc(msg_size);
    *header_space = malloc(sizeof(message_t));
    return 0;

--- a/src/biter/shmutil.c
+++ b/src/biter/shmutil.c
@@ -28,6 +28,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "shmutil.h"
 #include "sheep.h"
 #include "spindle_launch.h"
+#include "ccwarns.h"
 
 static pid_t gettid()
 {
@@ -185,8 +186,11 @@ int init_heap_lock(shminfo_t *shminfo)
       return 0;
    initialized = 1;
 
-   shminfo->mem_lock.lock = shminfo->shared_header->base.lock;
-   shminfo->mem_lock.held_by = shminfo->shared_header->base.held_by;
+   GCC_DISABLE_WARNING("-Wincompatible-pointer-types")
+   // unsigned long int * assigned to volatile pid_t *
+   shminfo->mem_lock.lock = shminfo->shared_header->base.locks + 0;
+   shminfo->mem_lock.held_by = shminfo->shared_header->base.locks + 1;
+   GCC_ENABLE_WARNING
    return 0;
 }
 

--- a/src/biter/shmutil.c
+++ b/src/biter/shmutil.c
@@ -185,8 +185,8 @@ int init_heap_lock(shminfo_t *shminfo)
       return 0;
    initialized = 1;
 
-   shminfo->mem_lock.lock = shminfo->shared_header->base.locks + 0;
-   shminfo->mem_lock.held_by = shminfo->shared_header->base.locks + 1;
+   shminfo->mem_lock.lock = shminfo->shared_header->base.lock;
+   shminfo->mem_lock.held_by = shminfo->shared_header->base.held_by;
    return 0;
 }
 

--- a/src/biter/shmutil.h
+++ b/src/biter/shmutil.h
@@ -85,6 +85,6 @@ int setup_ids(shminfo_t *shminfo);
 int take_heap_lock(shminfo_t *shminfo);
 int release_heap_lock(shminfo_t *shminfo);
 
-void update_shm_id();
+void update_shm_id(shminfo_t *shminfo);
 
 #endif

--- a/src/biter/shmutil.h
+++ b/src/biter/shmutil.h
@@ -17,18 +17,20 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #if !defined(SHMUTIL_H_)
 #define SHMUTIL_H_
 
+#include <sys/types.h>
 #include "sheep.h"
 #include "spindle_launch.h"
 
 typedef struct {
    volatile unsigned long *lock;
-   volatile unsigned long *held_by;
+   volatile pid_t *held_by;
    int ref_count;
 } lock_t;
 
 typedef struct {
    volatile int cur_id;
-   unsigned long locks[2];
+   unsigned long *lock;
+   pid_t *held_by;
 } base_header_t;
 
 #include "demultiplex.h"
@@ -43,11 +45,13 @@ typedef struct {
    int num_ranks;
    int read_file;
    int num_started;
-   unsigned long locks[6];
+   unsigned long lock[3];
+   pid_t held_by[3];
 } biter_header_t;
 
 typedef struct {
-   unsigned long locks[2];
+   unsigned long *lock;
+   pid_t *held_by;
    sheep_ptr_t hash;
    sheep_ptr_t lru_head;
    sheep_ptr_t lru_end;

--- a/src/biter/shmutil.h
+++ b/src/biter/shmutil.h
@@ -29,8 +29,7 @@ typedef struct {
 
 typedef struct {
    volatile int cur_id;
-   unsigned long *lock;
-   pid_t *held_by;
+   unsigned long locks[2];
 } base_header_t;
 
 #include "demultiplex.h"
@@ -45,13 +44,11 @@ typedef struct {
    int num_ranks;
    int read_file;
    int num_started;
-   unsigned long lock[3];
-   pid_t held_by[3];
+   unsigned long locks[6];
 } biter_header_t;
 
 typedef struct {
-   unsigned long *lock;
-   pid_t *held_by;
+   unsigned long locks[2];
    sheep_ptr_t hash;
    sheep_ptr_t lru_head;
    sheep_ptr_t lru_end;

--- a/src/client/auditclient/auditclient.c
+++ b/src/client/auditclient/auditclient.c
@@ -29,6 +29,7 @@ extern void restore_pathpatch();
 
 unsigned int spindle_la_version(unsigned int version)
 {
+   (void)version;
    patchDTV_init();
    return 1;
 }
@@ -51,6 +52,8 @@ void spindle_la_activity (uintptr_t *cookie, unsigned int flag)
 
 unsigned int spindle_la_objopen(struct link_map *map, Lmid_t lmid, uintptr_t *cookie)
 {
+   (void)lmid;
+   (void)cookie;
    char buffer[4096];
    char *exe_name, *exe_name2;
 
@@ -73,5 +76,6 @@ unsigned int spindle_la_objopen(struct link_map *map, Lmid_t lmid, uintptr_t *co
 
 unsigned int spindle_la_objclose(uintptr_t *cookie)
 {
+   (void)cookie;
    return 0;
 }

--- a/src/client/auditclient/auditclient_x86_64.c
+++ b/src/client/auditclient/auditclient_x86_64.c
@@ -41,6 +41,10 @@ Elf64_Addr la_x86_64_gnu_pltenter(Elf64_Sym *sym,
                                   const char *symname,
                                   long int *framesizep)
 {
+   (void)ndx;
+   (void)defcook;
+   (void)flags;
+   (void)framesizep;
    struct link_map *map = get_linkmap_from_cookie(refcook);
    unsigned long reloc_index = *((unsigned long *) (regs->lr_rsp-8));
    Elf64_Addr target = client_call_binding(symname, sym->st_value);
@@ -53,6 +57,9 @@ uintptr_t la_symbind64(Elf64_Sym *sym, unsigned int ndx,
 {
 //   struct link_map *rmap = get_linkmap_from_cookie(refcook);
 //   struct link_map *dmap = get_linkmap_from_cookie(defcook);
+   (void)ndx;
+   (void)refcook;
+   (void)defcook;
    updateDataBindingQueue(0);
    Elf64_Addr target = client_call_binding(symname, sym->st_value);
    *flags = 0;

--- a/src/client/auditclient/bindgot.c
+++ b/src/client/auditclient/bindgot.c
@@ -131,6 +131,7 @@ Elf64_Addr doPermanentBinding_noidx(uintptr_t *refcook, uintptr_t *defcook,
                                     Elf64_Addr target, const char *symname,
                                     void *stack_begin, void *stack_end)
 {
+   (void)defcook;
    int plt_reloc_idx;
    Elf64_Rela *rels = NULL, *rel;
    Elf64_Xword relsize = 0;
@@ -247,6 +248,7 @@ Elf64_Addr doPermanentBinding_idx(struct link_map *map,
                                   Elf64_Addr target,
                                   const char *symname)
 {
+   (void)symname;
    Elf64_Dyn *dynamic_section = map->l_ld;
    Elf64_Addr *got_entry;
    Elf64_Rela *rel = NULL;

--- a/src/client/auditclient/writablegot.c
+++ b/src/client/auditclient/writablegot.c
@@ -68,6 +68,7 @@ int add_wgot_library(struct link_map *map)
    unsigned long rel_size = 0, relent_size = 0, relcount = 0, plt_gotsize = 0, start, end;
    unsigned long datarels_size = 0, largest_datarel_target = 0, smallest_datarel_target = 0;
    signed int i;
+   unsigned int j;
    struct got_range_t *tmprange;
    
 
@@ -118,9 +119,9 @@ int add_wgot_library(struct link_map *map)
    plt_gotsize = (relcount + EXTRA_GOT_ENTRIES + 1) * sizeof(void*);
 
    if (datarels) {
-      for (i = 0; i < datarels_size / relent_size; i++) {
-         unsigned long target = datarels[i].r_offset + map->l_addr;
-         if (ELF64_R_TYPE(datarels[i].r_info) != DATA_GOT_TYPE)
+      for (j = 0; j < datarels_size / relent_size; j++) {
+         unsigned long target = datarels[j].r_offset + map->l_addr;
+         if (ELF64_R_TYPE(datarels[j].r_info) != DATA_GOT_TYPE)
             continue;
          largest_datarel_target = MAX(target, largest_datarel_target);
          if (!smallest_datarel_target) smallest_datarel_target = target;

--- a/src/client/beboot/spindle_bootstrap.c
+++ b/src/client/beboot/spindle_bootstrap.c
@@ -282,6 +282,7 @@ static void get_clientlib()
 
 void test_log(const char *name)
 {
+   (void)name;
 }
 
 static int handle_exec_failure(char **cmdline, int errno_val)

--- a/src/client/biter/Makefile.am
+++ b/src/client/biter/Makefile.am
@@ -6,7 +6,7 @@ libbiterc_la_LIBADD = libsheep.la
 
 libsheep_la_SOURCES = $(top_srcdir)/../biter/sheep.c $(top_srcdir)/../biter/shmutil.c $(top_srcdir)/../biter/shm_wrappers.c
 
-AM_CPPFLAGS = -I$(top_srcdir)/../biter -I$(top_srcdir)/../logging -I$(top_srcdir)/../include
+AM_CPPFLAGS = -I$(top_srcdir)/../biter -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/../utils
 AM_CFLAGS = -fvisibility=hidden
 
 if BGQ_BLD

--- a/src/client/biter/Makefile.in
+++ b/src/client/biter/Makefile.in
@@ -353,7 +353,8 @@ libbiterc_la_CFLAGS = -DCLIENT
 libbiterc_la_LIBADD = libsheep.la
 libsheep_la_SOURCES = $(top_srcdir)/../biter/sheep.c $(top_srcdir)/../biter/shmutil.c $(top_srcdir)/../biter/shm_wrappers.c
 AM_CPPFLAGS = -I$(top_srcdir)/../biter -I$(top_srcdir)/../logging \
-	-I$(top_srcdir)/../include $(am__append_1)
+	-I$(top_srcdir)/../include -I$(top_srcdir)/../utils \
+	$(am__append_1)
 AM_CFLAGS = -fvisibility=hidden
 all: all-am
 

--- a/src/client/client/client.c
+++ b/src/client/client/client.c
@@ -91,6 +91,8 @@ static char *concatStrings(const char *str1, const char *str2)
 static int find_libs_iterator(struct dl_phdr_info *lib,
                               size_t size, void *data)
 {
+   (void)size;
+   (void)data;
    if (!libc_name && (strstr(lib->dlpi_name, "libc.") || strstr(lib->dlpi_name, "libc-"))) {
       libc_name = lib->dlpi_name;
       libc_phdrs = lib->dlpi_phdr;

--- a/src/client/client/client.h
+++ b/src/client/client/client.h
@@ -69,7 +69,7 @@ void remove_libc_rogot();
 int handle_stat(const char *path, struct stat *buf, int flags);
 int open_worker(const char *path, int oflag, mode_t mode, int is_64);
 FILE *fopen_worker(const char *path, const char *mode, int is_64);
-void remap_executable();
+void remap_executable(int ldcsid);
 int get_ldso_metadata_bindingoffset(signed int *binding_offset);
 int get_ldso_metadata_statdata(signed long *stat_offset, signed long *lstat_offset, signed long *errno_offset);
 

--- a/src/client/client/exec_util.c
+++ b/src/client/client/exec_util.c
@@ -198,7 +198,8 @@ int adjust_if_script(const char *orig_path, char *reloc_path, char **argv, char 
    for (i = 0; i < interp_argc; i++)
       (*new_argv)[j++] = spindle_strdup(interpreter_args[i]);
    /* If argv[0] is not a path, replace with absolute path to mimic kernel behavior */
-   (*new_argv)[j++] = (argv[0] && strchr(argv[0], '/')) ? argv[0] : orig_path;
+   char *orig_path_copy = strdup( orig_path ); /* Preserve constness of orig_path. */
+   (*new_argv)[j++] = (argv[0] && strchr(argv[0], '/')) ? argv[0] : orig_path_copy;
    for (i = 1; i < argc; i++) {
       (*new_argv)[j++] = argv[i];
    }

--- a/src/client/client/intercept_readlink.c
+++ b/src/client/client/intercept_readlink.c
@@ -118,7 +118,7 @@ ssize_t readlink_wrapper(const char *path, char *buf, size_t bufsiz)
    if (len > bufsiz)
       len = bufsiz;
    memcpy(buf, resultpath, len);
-   debug_printf2("spindle readlink translated %s to %.*s with len %zu\n", path, len, buf, len);
+   debug_printf2("spindle readlink translated %s to %.*s with len %zu\n", path, (int)len, buf, len);
    return len;
 }
 
@@ -149,6 +149,6 @@ ssize_t readlinkat_wrapper(int dirfd, const char *path, char *buf, size_t bufsiz
    if (len > bufsiz)
       len = bufsiz;
    memcpy(buf, newbuf, len);
-   debug_printf2("spindle readlink translated %s to %.*s with len %zu\n", path, len, newbuf, len);
+   debug_printf2("spindle readlink translated %s to %.*s with len %zu\n", path, (int)len, newbuf, len);
    return (ssize_t) len;
 }

--- a/src/client/client/intercept_readlink.c
+++ b/src/client/client/intercept_readlink.c
@@ -56,7 +56,8 @@ static int fix_local_readlink(char *buf, size_t bufsiz)
 ssize_t readlink_wrapper(const char *path, char *buf, size_t bufsiz)
 {
    char resultpath[MAX_PATH_LEN+1];
-   int intercept_result, result, len, readlink_errcode;
+   int intercept_result, result, readlink_errcode;
+   size_t len;
    ssize_t rl_result;
 
    check_for_fork();
@@ -117,7 +118,7 @@ ssize_t readlink_wrapper(const char *path, char *buf, size_t bufsiz)
    if (len > bufsiz)
       len = bufsiz;
    memcpy(buf, resultpath, len);
-   debug_printf2("spindle readlink translated %s to %.*s with len %d\n", path, len, buf, len);
+   debug_printf2("spindle readlink translated %s to %.*s with len %zu\n", path, len, buf, len);
    return len;
 }
 
@@ -125,7 +126,8 @@ ssize_t readlinkat_wrapper(int dirfd, const char *path, char *buf, size_t bufsiz
 {
    char newbuf[MAX_PATH_LEN+1];
    ssize_t rl_result;
-   int result, len;
+   size_t len;
+   int result;
    
    debug_printf2("Intercepted readlinkat on %s\n", path);
 
@@ -147,6 +149,6 @@ ssize_t readlinkat_wrapper(int dirfd, const char *path, char *buf, size_t bufsiz
    if (len > bufsiz)
       len = bufsiz;
    memcpy(buf, newbuf, len);
-   debug_printf2("spindle readlink translated %s to %.*s with len %d\n", path, len, newbuf, len);
+   debug_printf2("spindle readlink translated %s to %.*s with len %zu\n", path, len, newbuf, len);
    return (ssize_t) len;
 }

--- a/src/client/client/intercept_stat.c
+++ b/src/client/client/intercept_stat.c
@@ -261,6 +261,7 @@ int rtcache_fxstat64(int vers, int fd, struct stat *buf)
 static int *ldso_errno;
 int ldso_xstat(int ver, const char *filename, struct stat *buf)
 {
+   (void)ver;
    int result;
    result = handle_stat(filename, buf, FROM_LDSO);
    if (result != 0) {
@@ -273,6 +274,7 @@ int ldso_xstat(int ver, const char *filename, struct stat *buf)
 
 int ldso_lxstat(int ver, const char *filename, struct stat *buf)
 {
+   (void)ver;
    int result;
    result = handle_stat(filename, buf, FROM_LDSO | IS_LSTAT);   
    if (result != 0) {

--- a/src/client/client/realpath.c
+++ b/src/client/client/realpath.c
@@ -109,6 +109,7 @@ B. Use spindle versions of the IO accessing lower-level routines.
 The source file is glibc/stdlib/canonicalize.c at git commit 1894e219dc530d7074085e95ffe3c1e66cebc072
  */
 
+#pragma GCC diagnostic ignored "-Wsign-compare"
 #define ISSLASH(c) ((c) == '/')
 #define PATH_MAX 4096
 #define IS_ABSOLUTE_FILE_NAME(name) (ISSLASH((name)[0]))

--- a/src/client/client/realpath.c
+++ b/src/client/client/realpath.c
@@ -21,6 +21,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <stdlib.h>
 #include <unistd.h>
 #include <stdio.h>
+#include "ccwarns.h"
 
 #if !defined(RPTEST)
 #include "intercept.h"
@@ -109,7 +110,6 @@ B. Use spindle versions of the IO accessing lower-level routines.
 The source file is glibc/stdlib/canonicalize.c at git commit 1894e219dc530d7074085e95ffe3c1e66cebc072
  */
 
-#pragma GCC diagnostic ignored "-Wsign-compare"
 #define ISSLASH(c) ((c) == '/')
 #define PATH_MAX 4096
 #define IS_ABSOLUTE_FILE_NAME(name) (ISSLASH((name)[0]))
@@ -366,6 +366,7 @@ realpath_stk (const char *name, char *resolved, struct realpath_bufs *bufs)
          if (!ISSLASH (dest[-1]))
             *dest++ = '/';
 
+         GCC_DISABLE_WARNING("-Wsign-compare")  // long int vs long unsigned int
          while (rname + bufs->rname.length - dest
                 < startlen + sizeof dir_suffix)
          {
@@ -375,6 +376,7 @@ realpath_stk (const char *name, char *resolved, struct realpath_bufs *bufs)
             rname = bufs->rname.data;
             dest = rname + dest_offset;
          }
+         GCC_ENABLE_WARNING
 
          dest = mempcpy (dest, start, startlen);
          *dest = '\0';

--- a/src/client/client/remap_exec.c
+++ b/src/client/client/remap_exec.c
@@ -37,11 +37,12 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 static int pagesize;
 
-static int fetchPhdrs(ElfW(Addr) *aout_base, ElfW(Phdr) **phdrs, unsigned int *phdrs_size)
+static int fetchPhdrs(ElfW(Addr) *aout_base, ElfW(Phdr) **phdrs, size_t *phdrs_size)
 {
    pid_t pid;
    char auxvpath[64];
-   int fd = 0, result, i;
+   int fd = 0, result;
+   size_t i;
    ElfW(auxv_t) auxv;
    ElfW(Phdr) *phdr;
    ElfW(Addr) phdr_offset = 0;
@@ -104,7 +105,7 @@ static int fetchPhdrs(ElfW(Addr) *aout_base, ElfW(Phdr) **phdrs, unsigned int *p
 
    *aout_base = (ElfW(Addr)) (((unsigned long) *phdrs) - phdr_offset);
 
-   debug_printf("Remapping a.out.  %u program headers at %p.  Program base at %lx\n",
+   debug_printf("Remapping a.out.  %zu program headers at %p.  Program base at %lx\n",
                 *phdrs_size, *phdrs, (unsigned long) *aout_base);
 
    return 0;
@@ -169,7 +170,7 @@ void remap_executable(int ldcsid)
 {
    ElfW(Addr) aout_base;
    ElfW(Phdr) *phdrs, *p;
-   unsigned int phdrs_size, i;
+   size_t phdrs_size, i;
    int result;
    int exe_fd;
 

--- a/src/client/client/should_intercept.c
+++ b/src/client/client/should_intercept.c
@@ -78,6 +78,7 @@ static int is_python_path(const char *pathname)
 
 static int is_python(const char *pathname, char *last_dot)
 {
+   (void)pathname;
    if (last_dot &&
        (strcmp(last_dot, ".py") == 0 ||
         strcmp(last_dot, ".pyc") == 0 ||
@@ -88,6 +89,7 @@ static int is_python(const char *pathname, char *last_dot)
 
 static int is_compiled_python(const char *pathname, char *last_dot)
 {
+   (void)pathname;
    if (last_dot &&
        (strcmp(last_dot, ".pyc") == 0 ||
         strcmp(last_dot, ".pyo") == 0))
@@ -97,6 +99,7 @@ static int is_compiled_python(const char *pathname, char *last_dot)
 
 static int is_dso(const char *pathname, char *last_slash, char *last_dot)
 {
+   (void)pathname;
    if (last_dot &&
        strcmp(last_dot, ".so") == 0)
       return 1;

--- a/src/client/client_comlib/client_api.c
+++ b/src/client/client_comlib/client_api.c
@@ -208,9 +208,9 @@ int send_orig_path_request(int fd, const char *path, char *newpath)
 int send_dirlists_request(int fd, char **local_result, char **exece_result, char **to_free)
 {
    ldcs_message_t message;
-   int local_len, ee_len;
+   unsigned int local_len, ee_len;
    char *buffer;
-   int buffer_pos = 0;
+   unsigned int buffer_pos = 0;
    
    message.header.type = LDCS_MSG_DIRLISTS_REQ;
    message.header.len = 0;

--- a/src/client/client_comlib/client_api_biter.c
+++ b/src/client/client_comlib/client_api_biter.c
@@ -34,6 +34,7 @@ extern unsigned int shm_cachesize;
 
 int client_open_connection_biter(char* location, number_t number)
 {
+   (void)number;
    debug_printf3("Calling biterc_newsession(%s, %lu)\n", location, (unsigned long) shm_cachesize);
    session = biterc_newsession(location, shm_cachesize);
    if (session == -1) {
@@ -55,11 +56,13 @@ int client_close_connection_biter(int connid)
 
 int client_register_connection_biter(char *connection_str)
 {
+   (void)connection_str;
    return 0;
 }
 
 char *client_get_connection_string_biter(int fd)
 {
+   (void)fd;
    return NULL;
 }
 
@@ -146,5 +149,6 @@ int client_recv_msg_dynamic_biter(int fd, ldcs_message_t *msg, ldcs_read_block_t
 
 int is_client_fd(int connid, int fd)
 {
+   (void)connid;
    return biterc_is_client_fd(session, fd);
 }

--- a/src/client/client_comlib/client_api_pipe.c
+++ b/src/client/client_comlib/client_api_pipe.c
@@ -190,6 +190,7 @@ static int remap_to_high_fd(int fd)
 
 int client_open_connection_pipe(char* location, number_t number)
 {
+   (void)number;
    int fd, result;
    struct stat st;
    int stat_cnt;

--- a/src/client/client_comlib/client_api_socket.c
+++ b/src/client/client_comlib/client_api_socket.c
@@ -42,10 +42,9 @@ static int get_new_fd_socket()
    return 0;
 }
 
-static int _ldcs_read_socket(int fd, void *data, int bytes, ldcs_read_block_t block) {
+static size_t _ldcs_read_socket(int fd, void *data, int bytes, ldcs_read_block_t block) {
 
-  int         left,bsumread;
-  ssize_t      btoread, bread;
+  ssize_t    btoread, bread, left, bsumread;
   char       *dataptr;
   
   left      = bytes;
@@ -61,10 +60,10 @@ static int _ldcs_read_socket(int fd, void *data, int bytes, ldcs_read_block_t bl
 	if(block==LDCS_READ_NO_BLOCK) return(0);
 	else continue;
       } else { 
-         debug_printf3("read from socket: %ld bytes ... errno=%d (%s)\n",bread,errno,strerror(errno));
+         debug_printf3("read from socket: %zu bytes ... errno=%d (%s)\n",bread,errno,strerror(errno));
       }
     } else {
-      debug_printf3("read from socket: %ld bytes ...\n",bread);
+      debug_printf3("read from socket: %zu bytes ...\n",bread);
     }
 
     if(bread>0) {
@@ -198,7 +197,7 @@ int client_send_msg_socket(int fd, ldcs_message_t * msg) {
   connfd=ldcs_socket_fdlist[fd].fd;
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("sending message of type: %s len=%lu data=%s ...\n",
+  debug_printf3("sending message of type: %s len=%zu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
 
@@ -216,15 +215,14 @@ int client_send_msg_socket(int fd, ldcs_message_t * msg) {
 
 int client_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_t block) {
   char help[41];
-  int rc=0;
-  int n, connfd;
+  int rc=0, connfd;
+  size_t n;
   if ((fd<0) || (fd>MAX_FD) )  _error("wrong fd");
   connfd=ldcs_socket_fdlist[fd].fd;
 
 
   n = _ldcs_read_socket(connfd,&msg->header,sizeof(msg->header), block);
   if (n == 0) return(rc);
-  if (n < 0) _error("ERROR reading header from socket");
 
   if(msg->header.len>0) {
 
@@ -233,7 +231,6 @@ int client_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_
     
     n = _ldcs_read_socket(connfd,msg->data,msg->header.len, LDCS_READ_BLOCK);
     if (n == 0) return(rc);
-    if (n < 0) _error("ERROR reading message data from socket");
     if (n != msg->header.len) _error("received different number of bytes for message data");
 
   } else {
@@ -241,7 +238,7 @@ int client_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_
   }
 
   bzero(help,41);if(msg->data) strncpy(help,msg->data,40);
-  debug_printf3("received message of type: %s len=%lu data=%s ...\n",
+  debug_printf3("received message of type: %s len=%zu data=%s ...\n",
 	       _message_type_to_str(msg->header.type),
 	       msg->header.len,help );
   

--- a/src/client/ldsolookup/print_ldso_entry.c
+++ b/src/client/ldsolookup/print_ldso_entry.c
@@ -10,6 +10,7 @@
 
 int main(int argc, char *argv[])
 {
+   (void)argc;
    ElfW(Dyn) *dyn;
    ElfW(Addr) *pltgot = NULL;
    char path[4097];

--- a/src/client/shm_cache/Makefile.am
+++ b/src/client/shm_cache/Makefile.am
@@ -7,5 +7,5 @@ if BITER
 else
 libshmcache_la_LIBADD = $(top_builddir)/biter/libsheep.la
 endif
-AM_CPPFLAGS = -I$(top_srcdir)/../biter -I$(top_srcdir)/shm_cache -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/../include
+AM_CPPFLAGS = -I$(top_srcdir)/../biter -I$(top_srcdir)/shm_cache -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/../include -I$(top_srcdir)/../utils
 

--- a/src/client/shm_cache/Makefile.in
+++ b/src/client/shm_cache/Makefile.in
@@ -318,7 +318,7 @@ noinst_LTLIBRARIES = libshmcache.la
 AM_CFLAGS = -fvisibility=hidden
 libshmcache_la_SOURCES = shmcache.c
 @BITER_FALSE@libshmcache_la_LIBADD = $(top_builddir)/biter/libsheep.la
-AM_CPPFLAGS = -I$(top_srcdir)/../biter -I$(top_srcdir)/shm_cache -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/../include
+AM_CPPFLAGS = -I$(top_srcdir)/../biter -I$(top_srcdir)/shm_cache -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/../include -I$(top_srcdir)/../utils
 all: all-am
 
 .SUFFIXES:

--- a/src/client/shm_cache/shmcache.c
+++ b/src/client/shm_cache/shmcache.c
@@ -20,6 +20,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "client_heap.h"
 #include "shmutil.h"
 #include "spindle_debug.h"
+#include "ccwarns.h"
 #include <string.h>
 #include <assert.h>
 
@@ -397,8 +398,11 @@ static int shmcache_add_worker(const char *libname, const char *mapped_name, int
 
 static int init_cache_locks()
 {
-   cache_lock.lock = shminfo->shared_header->shmcache.lock;
-   cache_lock.held_by = shminfo->shared_header->shmcache.held_by;
+   cache_lock.lock = shminfo->shared_header->shmcache.locks + 0;
+   GCC_DISABLE_WARNING("-Wincompatible-pointer-types")
+   // unsigned long int * assigned to volatile pid_t *
+   cache_lock.held_by = shminfo->shared_header->shmcache.locks + 1;
+   GCC_ENABLE_WARNING
 
    return init_heap_lock(shminfo);
 }

--- a/src/client/shm_cache/shmcache.c
+++ b/src/client/shm_cache/shmcache.c
@@ -397,8 +397,8 @@ static int shmcache_add_worker(const char *libname, const char *mapped_name, int
 
 static int init_cache_locks()
 {
-   cache_lock.lock = shminfo->shared_header->shmcache.locks + 0;
-   cache_lock.held_by = shminfo->shared_header->shmcache.locks + 1;
+   cache_lock.lock = shminfo->shared_header->shmcache.lock;
+   cache_lock.held_by = shminfo->shared_header->shmcache.held_by;
 
    return init_heap_lock(shminfo);
 }

--- a/src/client/subaudit/subaudit.c
+++ b/src/client/subaudit/subaudit.c
@@ -27,6 +27,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 unsigned int spindle_la_version(unsigned int version)
 {
+   (void)version;
    int result;
    int binding_offset = 0;
 
@@ -55,12 +56,16 @@ static void bind_to_libc()
 
 void spindle_la_activity(uintptr_t *cookie, unsigned int flag)
 {
+   (void)cookie;
+   (void)flag;
    bind_to_libc();
    update_plt_bindings();
 }
 
 unsigned int spindle_la_objopen(struct link_map *map, Lmid_t lmid, uintptr_t *cookie)
 {
+   (void)lmid;
+   (void)cookie;
    bind_to_libc();
    add_library_to_plt_update_list(map);
    return 0;

--- a/src/client/subaudit/update_pltbind.c
+++ b/src/client/subaudit/update_pltbind.c
@@ -178,7 +178,8 @@ void add_library_to_plt_update_list(struct link_map *lmap)
 
 void remove_library_from_plt_update_list(struct link_map *lmap)
 {
-   int i, found = -1;
+   unsigned int i;
+   int found = -1;
    if (!update_list_cur)
       return;
 

--- a/src/cobo/cobo.c
+++ b/src/cobo/cobo.c
@@ -1344,6 +1344,9 @@ int cobo_allgather(void* sendbuf, int sendcount, void* recvbuf)
  */
 int cobo_alltoall(void* sendbuf, int sendcount, void* recvbuf)
 {
+    (void)sendbuf;
+    (void)sendcount;
+    (void)recvbuf;
     struct timeval start, end;
     cobo_gettimeofday(&start);
     debug_printf3("Starting cobo_alltoall()");

--- a/src/cobo/cobo.c
+++ b/src/cobo/cobo.c
@@ -473,8 +473,7 @@ static int cobo_connect_hostname(char* hostname, int rank)
     struct hostent* he = gethostbyname(hostname);
     if (!he) {
        /* gethostbyname doesn't know how to resolve hostname, trying inet_addr */ 
-       saddr.s_addr = inet_addr(hostname);
-       if (saddr.s_addr == -1) {
+       if ( inet_aton( hostname, &saddr ) == 0 ){
            err_printf("Hostname lookup failed (gethostbyname(%s) %s h_errno=%d)\n",
                 hostname, hstrerror(h_errno), h_errno);
            return s;

--- a/src/cobo/handshake.c
+++ b/src/cobo/handshake.c
@@ -136,10 +136,10 @@ static int none_encrypt_packet(void *packet, size_t packet_size,
                                unsigned char **packet_buffer, size_t *packet_buffer_size);
 static int munge_encrypt_packet(void *packet, size_t packet_size,
                                 unsigned char **packet_buffer, size_t *packet_buffer_size);
-static int filekey_encrypt_packet(char *key_filepath, int key_length_bytes,
+static int filekey_encrypt_packet(char *key_filepath, ssize_t key_length_bytes,
                                   void *packet, size_t packet_size,
                                   unsigned char **packet_buffer, size_t *packet_buffer_size);
-static int key_encrypt_packet(unsigned char *key, int key_length_bytes,
+static int key_encrypt_packet(unsigned char *key, ssize_t key_length_bytes,
                               void *packet, size_t packet_size,
                               unsigned char **packet_buffer, size_t *packet_buffer_size);
 
@@ -161,9 +161,9 @@ static int handshake_wrapper(int sockfd, handshake_protocol_t *hdata, uint64_t s
                              int is_server);
 static int handshake_main(int sockfd, handshake_protocol_t *hdata, uint64_t session_id,
                           int is_server);
-static int reliable_write(int fd, const void *buf, size_t size);
-static int reliable_read(int fd, void *buf, size_t size);
-static int read_key(char *key_filepath, int key_length_bytes);
+static ssize_t reliable_write(int fd, const void *buf, ssize_t size);
+static ssize_t reliable_read(int fd, void *buf, ssize_t size);
+static int read_key(char *key_filepath, ssize_t key_length_bytes);
 static int share_result(int fd, int result);
 static int get_client_server_addrs(int sockfd, int i_am_server, connection_info_t *conninfo);
 static int send_packet(int sockfd, unsigned char *packet, unsigned int packet_size);
@@ -685,9 +685,10 @@ static int munge_encrypt_packet(void *packet, size_t packet_size,
 #endif
 }
 
-static int read_key(char *key_filepath, int key_length_bytes)
+static int read_key(char *key_filepath, ssize_t key_length_bytes)
 {
-   int result, fd = -1;
+   ssize_t result;
+   int fd = -1;
    struct stat st;
    int return_result;
    uid_t uid = getuid();
@@ -753,7 +754,7 @@ static int read_key(char *key_filepath, int key_length_bytes)
    buffer = malloc(key_length_bytes);
    assert(buffer);
    result = reliable_read(fd, buffer, key_length_bytes);
-   if (result != key_length_bytes) {
+   if (result != (ssize_t)key_length_bytes) {
       security_error_printf("Unable to read from key file %s: %s\n", key_filepath, strerror(errno));
       return_result = HSHAKE_ABORT;
       goto done;
@@ -773,7 +774,7 @@ static int read_key(char *key_filepath, int key_length_bytes)
    return return_result;
 }
 
-static int filekey_encrypt_packet(char *key_filepath, int key_length_bytes,
+static int filekey_encrypt_packet(char *key_filepath, ssize_t key_length_bytes,
                                   void *packet, size_t packet_size,
                                   unsigned char **packet_buffer, size_t *packet_buffer_size)
 {
@@ -839,7 +840,7 @@ static int get_hash_of_buffer(unsigned char *buffer, size_t buffer_size,
 
 #endif
 
-static int key_encrypt_packet(unsigned char *key, int key_length_bytes,
+static int key_encrypt_packet(unsigned char *key, ssize_t key_length_bytes,
                               void *packet, size_t packet_size,
                               unsigned char **packet_buffer, size_t *packet_buffer_size)
 {
@@ -879,10 +880,10 @@ static int key_encrypt_packet(unsigned char *key, int key_length_bytes,
 #endif   
 }
 
-static int reliable_write(int fd, const void *buf, size_t size)
+static ssize_t reliable_write(int fd, const void *buf, ssize_t size)
 {
    int result;
-   size_t bytes_written = 0;
+   ssize_t bytes_written = 0;
    while (bytes_written < size) {
       result = write(fd, ((unsigned char *) buf) + bytes_written, size - bytes_written);
       if (result == -1 && errno == EINTR)
@@ -897,10 +898,10 @@ static int reliable_write(int fd, const void *buf, size_t size)
    return bytes_written;
 }
 
-static int reliable_read(int fd, void *buf, size_t size)
+static ssize_t reliable_read(int fd, void *buf, ssize_t size)
 {
-   int result;
-   size_t bytes_read = 0;
+   ssize_t result;
+   ssize_t bytes_read = 0;
 
    while (bytes_read < size) {
       if (timeout_seconds) {
@@ -991,7 +992,8 @@ static int munge_decrypt_packet(void *recvd_packet, size_t recvd_packet_size,
    munge_err_t result;
    munge_ctx_t ctx = NULL;
    void *payload = NULL;
-   int payload_size, return_result = 0, iresult;
+   int payload_size;
+   int return_result = 0, iresult;
    uid_t uid;
    gid_t gid;
 
@@ -1042,7 +1044,7 @@ static int munge_decrypt_packet(void *recvd_packet, size_t recvd_packet_size,
          goto done;
    }
 
-   if (payload_size != recvd_packet_size) {
+   if (payload_size != (int)recvd_packet_size) {
       security_error_printf("Recieved munge packet with invalid payload size of %d\n", (int) payload_size);
       return_result = HSHAKE_ABORT;
       goto done;
@@ -1200,7 +1202,7 @@ static int compare_random_number_packets(random_number_packet_t *expected_random
 static int share_result(int fd, int handshake_result)
 {
    int32_t result_to_send, peer_result;
-   int result;
+   ssize_t result;
 
    switch (handshake_result) {
       case HSHAKE_SUCCESS:
@@ -1219,14 +1221,14 @@ static int share_result(int fd, int handshake_result)
    debug_printf("Sharing handshake result %d with peer\n", result_to_send);
       
    result = reliable_write(fd, &result_to_send, sizeof(result_to_send));
-   if (result != sizeof(result_to_send)) {
+   if (result != (ssize_t)sizeof(result_to_send)) {
       error_printf("Failed to send result of connection\n");
       return HSHAKE_INTERNAL_ERROR;
    }
    
    debug_printf("Reading peer result\n");
    result = reliable_read(fd, &peer_result, sizeof(peer_result));
-   if (result != sizeof(peer_result)) {
+   if (result != (ssize_t)sizeof(peer_result)) {
       debug_printf("Failed to read handshake result from peer\n");
       return result;
    }
@@ -1276,18 +1278,18 @@ static int get_client_server_addrs(int sockfd, int i_am_server,
 static int exchange_sig(int sockfd) 
 {
    uint32_t sig = SIG;
-   int result;
+   ssize_t result;
 
    debug_printf("Sending sig %x on network\n", sig);
    result = reliable_write(sockfd, &sig, sizeof(sig));
-   if (result != sizeof(sig)) {
+   if (result != (ssize_t)sizeof(sig)) {
       debug_printf("Problem writing sig on network\n");
       return HSHAKE_DROP_CONNECTION;
    }
 
    debug_printf("Receiving sig from network\n");
    result = reliable_read(sockfd, &sig, sizeof(sig));
-   if (result != sizeof(sig)) {
+   if (result != (ssize_t)sizeof(sig)) {
       debug_printf("Problem reading sig from network\n");
       return result;
    }
@@ -1302,19 +1304,19 @@ static int exchange_sig(int sockfd)
 static int send_packet(int sockfd, unsigned char *packet, unsigned int packet_size)
 {
    uint32_t size;
-   int result;
+   ssize_t result;
 
    debug_printf("Sending packet size on network\n");
    size = packet_size;
    result = reliable_write(sockfd, &size, sizeof(size));
-   if (result != sizeof(size)) {
+   if (result != (ssize_t)sizeof(size)) {
       debug_printf("Problem writing packet size on network\n");
       return HSHAKE_INTERNAL_ERROR;
    }
 
    debug_printf("Sending packet on network\n");
    result = reliable_write(sockfd, packet, packet_size);
-   if (result != packet_size) {
+   if (result != (ssize_t)packet_size) {
       debug_printf("Problem writing packet on network\n");
       return HSHAKE_INTERNAL_ERROR;
    }   
@@ -1325,11 +1327,11 @@ static int send_packet(int sockfd, unsigned char *packet, unsigned int packet_si
 static int recv_packet(int sockfd, unsigned char **packet, size_t *packet_size)
 {
    uint32_t size;
-   int result;
+   ssize_t result;
 
    debug_printf("Receiving packet size from network\n");
    result = reliable_read(sockfd, &size, sizeof(size));
-   if (result != sizeof(size)) {
+   if (result != (ssize_t)sizeof(size)) {
       debug_printf("Error reading packet size from network\n");
       return result;
    }
@@ -1341,7 +1343,7 @@ static int recv_packet(int sockfd, unsigned char **packet, size_t *packet_size)
    *packet = malloc(size);
    assert(*packet);
    result = reliable_read(sockfd, *packet, size);
-   if (result != size) {
+   if (result != (ssize_t)size) {
       debug_printf("Error reading packet from network\n");
       return result;
    }

--- a/src/cobo/handshake.c
+++ b/src/cobo/handshake.c
@@ -612,6 +612,10 @@ static int none_encrypt_packet(void *packet, size_t packet_size,
    memcpy(*packet_buffer, packet, *packet_buffer_size);
    return 0;
 #else
+   (void)packet;
+   (void)packet_size;
+   (void)packet_buffer;
+   (void)packet_buffer_size;
    error_printf("Null encryption must be explicitly enabled\n");
    return HSHAKE_INTERNAL_ERROR;
 #endif
@@ -875,6 +879,12 @@ static int key_encrypt_packet(unsigned char *key, ssize_t key_length_bytes,
 
    return 0;   
 #else
+   (void)key;
+   (void)key_length_bytes;
+   (void)packet;
+   (void)packet_size;
+   (void)packet_buffer;
+   (void)packet_buffer_size;
    error_printf("Handshake not built against gcrypt\n");
    return HSHAKE_INTERNAL_ERROR;
 #endif   
@@ -980,6 +990,10 @@ static int none_decrypt_packet(void *recvd_packet, size_t packet_size,
    memcpy(recvd_packet, recvd_buffer, recvd_buffer_size);
    return 0;
 #else
+   (void)recvd_packet;
+   (void)packet_size;
+   (void)recvd_buffer;
+   (void)recvd_buffer_size;
    error_printf("Null encryption must be explicitly enabled\n");
    return HSHAKE_INTERNAL_ERROR;
 #endif
@@ -988,6 +1002,7 @@ static int none_decrypt_packet(void *recvd_packet, size_t packet_size,
 static int munge_decrypt_packet(void *recvd_packet, size_t recvd_packet_size,
                                 unsigned char *recvd_buffer, size_t recvd_buffer_size)
 {
+   (void)recvd_buffer_size;
 #if defined(MUNGE)
    munge_err_t result;
    munge_ctx_t ctx = NULL;
@@ -1110,6 +1125,12 @@ static int key_decrypt_packet(unsigned char *key, unsigned int key_len,
    
    return return_result;
 #else
+   (void)key;
+   (void)key_len;
+   (void)recvd_packet;
+   (void)packet_size;
+   (void)recvd_buffer;
+   (void)recvd_buffer_size;
    error_printf("handshake was not compiled with gcrypt support");
    return HSHAKE_INTERNAL_ERROR;
 #endif

--- a/src/cobo/handshake.c
+++ b/src/cobo/handshake.c
@@ -422,7 +422,17 @@ static int handshake_main(int sockfd, handshake_protocol_t *hdata, uint64_t sess
    debug_printf("Decrypting their random number packet\n");
    result = decrypt_packet(hdata, &recvd_random_number_packet, sizeof(random_number_packet_t), recvd_packet_buffer, recvd_packet_buffer_size);
    if (result < 0) {
-      debug_printf("Error decrypting and checking received packet\n");
+      debug_printf("Error checking initial packet\n");
+      return_result = result;
+      goto done;
+   }
+
+   //encrypt random number packet that they are expecting
+   random_number_packet.random_number = recvd_packet.random_number;
+   random_number_packet.signature = packet.signature;
+   result = encrypt_packet(hdata, &random_number_packet, sizeof(random_number_packet_t), &packet_buffer, &packet_buffer_size);
+   if (result < 0) {
+      debug_printf("Error in server encrypting outgoing random_number_packet");
       return_result = result;
       goto done;
    }

--- a/src/cobo/handshake.c
+++ b/src/cobo/handshake.c
@@ -586,14 +586,14 @@ static int encrypt_packet(handshake_protocol_t *hdata, void *packet, size_t pack
          debug_printf("Server encrypting packet with munge\n");
          return munge_encrypt_packet(packet, packet_size, packet_buffer, packet_buffer_size);
       case hs_key_in_file:
-         debug_printf("Server encrypting packet with key of size %d from file %s\n",
+         debug_printf("Server encrypting packet with key of size %ld from file %s\n",
                       hdata->data.key_in_file.key_length_bytes,
                       hdata->data.key_in_file.key_filepath);
          return filekey_encrypt_packet(hdata->data.key_in_file.key_filepath,
                                        hdata->data.key_in_file.key_length_bytes,
                                        packet, packet_size, packet_buffer, packet_buffer_size);
       case hs_explicit_key:
-         debug_printf("Server encrypting packet with provided key of size %d\n",
+         debug_printf("Server encrypting packet with provided key of size %ld\n",
                       hdata->data.explicit_key.key_length_bytes);
          return key_encrypt_packet(hdata->data.explicit_key.key,
                                    hdata->data.explicit_key.key_length_bytes,

--- a/src/cobo/handshake.h
+++ b/src/cobo/handshake.h
@@ -52,11 +52,11 @@ typedef struct {
       } munge;
       struct {
          char *key_filepath;
-         int key_length_bytes;
+         ssize_t key_length_bytes;
       } key_in_file;
       struct {
          unsigned char *key;
-         int key_length_bytes;
+         ssize_t key_length_bytes;
       } explicit_key;
    } data;
 } handshake_protocol_t;

--- a/src/fe/comlib/cobo_fe_comm.c
+++ b/src/fe/comlib/cobo_fe_comm.c
@@ -57,7 +57,7 @@ int ldcs_audit_server_fe_md_open ( char **hostlist, int numhosts, unsigned int p
    int rc=0;
    int *portlist;
    int root_fd, ack;
-   int i;
+   unsigned int i;
 
    assert(num_ports >= 1);
    portlist = malloc(sizeof(int) * (num_ports+1));

--- a/src/fe/comlib/cobo_fe_comm.c
+++ b/src/fe/comlib/cobo_fe_comm.c
@@ -54,6 +54,7 @@ static int read_msg(int fd, ldcs_message_t *msg)
 int ldcs_audit_server_fe_md_open ( char **hostlist, int numhosts, unsigned int port, unsigned int num_ports,
                                    unique_id_t unique_id, 
                                    void **data  ) {
+   (void)data;
    int rc=0;
    int *portlist;
    int root_fd, ack;
@@ -167,7 +168,7 @@ int ldcs_audit_server_fe_md_waitfor_alive(int timeout_seconds)
 }
 
 int ldcs_audit_server_fe_md_close ( void *data  ) {
-  
+   (void)data;
    ldcs_message_t out_msg;
    int root_fd;
 
@@ -183,6 +184,7 @@ int ldcs_audit_server_fe_md_close ( void *data  ) {
 
 int ldcs_audit_server_fe_broadcast(ldcs_message_t *msg, void *data)
 {
+   (void)data;
    int root_fd;
 
    debug_printf("Broadcasting message to daemons\n");

--- a/src/fe/openmpi_intercept/ompi_intercept.c
+++ b/src/fe/openmpi_intercept/ompi_intercept.c
@@ -40,6 +40,9 @@ static volatile int doing_read = 0;
 
 void on_sigsegv(int sig, siginfo_t *info, void *ctx)
 {
+   (void)sig;
+   (void)info;
+   (void)ctx;
    if (!doing_read)
       return;
    siglongjmp(env, -1);
@@ -69,6 +72,7 @@ static int check_proctable_entry(MPIR_PROCDESC *e)
 
 static void *monitor_main(void *arg)
 {
+   (void)arg;
    struct sigaction act, oact;
    int i, ready = 0;
 

--- a/src/fe/startup/config_mgr.cc
+++ b/src/fe/startup/config_mgr.cc
@@ -814,6 +814,7 @@ bool ConfigMap::toSpindleArgs(spindle_args_t &args, bool alloc_strs) const
                setopt(args.opts, OPT_STOPRELOC, false);
                setopt(args.opts, OPT_OFF, true);
             }
+            break;
          case confPushpull:
             if (strresult == "pull") {
                setopt(args.opts, OPT_PULL, true);

--- a/src/fe/startup/launch_flux.cc
+++ b/src/fe/startup/launch_flux.cc
@@ -162,6 +162,9 @@ bool FluxLauncher::spawnJob(app_id_t id, int app_argc, char **app_argv)
    //Unsed for flux session launcher. Rather than launch jobs under spindle, we will
    // put spindle launch information in the flux KVS, then let the flux run spindle
    // plug-in capture that information during normal flux job runs.
+   (void)id;
+   (void)app_argc;
+   (void)app_argv;
    return false;
 }
 

--- a/src/fe/startup/launch_lsf.cc
+++ b/src/fe/startup/launch_lsf.cc
@@ -95,6 +95,7 @@ const char *LSFLauncher::getNextLSBHost(const char *prev)
 
 void LSFLauncher::countHost(const char *host, void *data, int)
 {
+   (void)host;
    int *count = (int *) data;
    (*count)++;
 }
@@ -156,6 +157,7 @@ bool LSFLauncher::spawnDaemon()
 
 bool LSFLauncher::spawnJob(app_id_t id, int app_argc, char **app_argv)
 {
+   (void)app_argc;
    debug_printf("Spindle launching LSF job with app-id %lu: %s\n", id, app_argv[0]);
    int pid = fork();
    if (pid == -1) {

--- a/src/fe/startup/launch_slurm.cc
+++ b/src/fe/startup/launch_slurm.cc
@@ -195,6 +195,7 @@ bool SlurmLauncher::spawnDaemon()
 
 bool SlurmLauncher::spawnJob(app_id_t id, int app_argc, char **app_argv)
 {
+   (void)app_argc;
    debug_printf("Spindle launching slurm job with app-id %lu: %s\n", id, app_argv[0]);
    int pid = fork();
    if (pid == -1) {

--- a/src/fe/startup/launcher.cc
+++ b/src/fe/startup/launcher.cc
@@ -84,6 +84,7 @@ void Launcher::getSecondaryDaemonArgs(vector<const char *> &)
 
 bool Launcher::setupJob(app_id_t id, int &app_argc, char** &app_argv)
 {
+   (void)id;
    int mod_argc;
    char **mod_argv;
 
@@ -279,16 +280,21 @@ const char *PassthroughLauncher::getDaemonArg()
 
 void PassthroughLauncher::getSecondaryDaemonArgs(std::vector<const char *> &secondary_args)
 {
+   (void)secondary_args;
    return;
 }
 
 bool PassthroughLauncher::setupJob(app_id_t id, int &app_argc, char** &app_argv)
 {
+   (void)id;
+   (void)app_argc;
+   (void)app_argv;
    return true;
 }
 
 bool PassthroughLauncher::spawnJob(app_id_t id, int app_argc, char **app_argv)
 {
+   (void)app_argc;
    debug_printf("Launching job with app-id %lu: %s\n", id, app_argv[0]);
    int pid = fork();
    if (pid == -1) {

--- a/src/fe/startup/parse_launcher_args.cc
+++ b/src/fe/startup/parse_launcher_args.cc
@@ -446,6 +446,7 @@ bool LauncherParser::parseCustomArg(int /*argc*/, char** /*argv*/, int /*arg_pos
  **/
 bool LauncherParser::includeArg(int argc, char **argv, int pos)
 {
+   (void)argc;
    if (argv[pos][0] == '\0')
       return false;
    return true;
@@ -670,6 +671,9 @@ bool SerialParser::usesLauncher() const
 
 bool SerialParser::isExecutable(int argc, char **argv, int pos, const set<string> &exedirs) const
 {
+   (void)argc;
+   (void)argv;
+   (void)exedirs;
    return (pos == 0);
 }
 
@@ -684,6 +688,8 @@ OpenMPIParser::~OpenMPIParser()
 
 bool OpenMPIParser::parseCustomArg(int argc, char **argv, int arg_pos, int &inc_argc) const
 {
+   (void)argc;
+   (void)inc_argc;
    fprintf(stderr, "%s under OpenMPI is not yet supported by Spindle\n", argv[arg_pos]);
    exit(-1);
 }
@@ -699,6 +705,8 @@ JSRunParser::~JSRunParser()
 
 bool JSRunParser::parseCustomArg(int argc, char **argv, int arg_pos, int &inc_argc) const
 {
+   (void)argc;
+   (void)inc_argc;
    if (strcmp(argv[arg_pos], "--use_spindle") == 0 || (strcmp(argv[arg_pos], "-L") == 0)) {
       fprintf(stderr, "Error: Do not mix spindle job launch wrapper with the jsrun spindle option %s. "
               "Use one or the other.\n", argv[arg_pos]);
@@ -720,6 +728,8 @@ LRunParser::~LRunParser()
 
 bool LRunParser::parseCustomArg(int argc, char **argv, int arg_pos, int &inc_argc) const
 {
+   (void)argc;
+   (void)inc_argc;
    if (strcmp(argv[arg_pos], "--use_spindle") == 0 || (strcmp(argv[arg_pos], "-L") == 0)) {
       fprintf(stderr, "Error: Do not mix spindle job launch wrapper with the lrun spindle option %s. "
               "Use one or the other.\n", argv[arg_pos]);
@@ -769,6 +779,8 @@ cmdoption_t *MarkerParser::getArg(int argc, char **argv, int pos) const
 
 bool MarkerParser::isExecutable(int argc, char **argv, int pos, const std::set<std::string> &exedirs) const
 {
+   (void)argc;
+   (void)exedirs;
    return (pos > 0 && strcmp(argv[pos-1], "spindlemarker") == 0);
 }
 

--- a/src/flux/flux-spindle.c
+++ b/src/flux/flux-spindle.c
@@ -126,6 +126,7 @@ static int spindle_in_session_mode(flux_t *flux_handle, int *argc, char ***argv)
 
 static void free_bootstrap_args(int argc, char **argv)
 {
+   (void)argc;
    int i;
    for (i = 0; argv[i] != NULL; i++)
       free(argv[i]);
@@ -242,6 +243,7 @@ static void spindle_ctx_destroy (struct spindle_ctx *ctx)
 
 static void onTermSignal(int sig)
 {
+   (void)sig;
    //Force an exit in the child.
    spindleForceExitBE(SPINDLE_EXIT_TYPE_SOFT);
    alarm(5); //Force shutdown in 5 seconds if not otherwise down
@@ -249,6 +251,7 @@ static void onTermSignal(int sig)
 
 static void onAlarm(int sig)
 {
+   (void)sig;
    spindleForceExitBE(SPINDLE_EXIT_TYPE_HARD);
    _exit(-1);
 }
@@ -514,6 +517,9 @@ static int sp_init (flux_plugin_t *p,
                     flux_plugin_arg_t *arg,
                     void *data)
 {
+    (void)topic;
+    (void)arg;
+    (void)data;
     struct spindle_ctx *ctx;
     flux_shell_t *shell = flux_plugin_get_shell (p);
     flux_t *h = flux_shell_get_flux (shell);
@@ -666,6 +672,9 @@ static int sp_task (flux_plugin_t *p,
                     flux_plugin_arg_t *arg,
                     void *data)
 {
+    (void)topic;
+    (void)arg;
+    (void)data;
     int session_mode;
     int bootstrap_argc;
     char **bootstrap_argv;
@@ -722,6 +731,9 @@ static int sp_exit (flux_plugin_t *p,
                     flux_plugin_arg_t *arg,
                     void *data)
 {
+   (void)topic;
+   (void)arg;
+   (void)data;
    flux_shell_t *shell = flux_plugin_get_shell (p);
     flux_t *h = flux_shell_get_flux (shell);
 

--- a/src/flux/fluxmgr.c
+++ b/src/flux/fluxmgr.c
@@ -227,6 +227,7 @@ int fluxmgr_get_from_kvs(char **daemon_args, int timeout_seconds)
 
 int fluxmgr_get_bootstrap(flux_t *fhandle, char **bootstrap_args)
 {
+   (void)fhandle;
    int result;
    result = get_from_kvs(NULL, "bootstrap_args", bootstrap_args, 0);
    if (result == GET_FROM_KVS_ERR || result == GET_FROM_KVS_TIMEOUT)

--- a/src/flux/spindlebemgr.c
+++ b/src/flux/spindlebemgr.c
@@ -29,6 +29,7 @@ static int decode_daemon_args(char *daemon_arg_str, unsigned int *port, unsigned
 
 static int post_setup(spindle_args_t *params)
 {
+   (void)params;
    ping_readymsg(0);
    clean_readymsg();
    return 0;
@@ -36,6 +37,8 @@ static int post_setup(spindle_args_t *params)
 
 int run_be(int argc, char **argv)
 {
+   (void)argv;
+   (void)argc;
    int result;
    char *daemon_arg_str;
    unsigned int port, num_ports;

--- a/src/include/ldcs_api_pipe.h
+++ b/src/include/ldcs_api_pipe.h
@@ -35,8 +35,8 @@ char *ldcs_get_connection_string_pipe(int fd);
 int ldcs_register_connection_pipe(char *connection_str);
 
 /* internal */
-int _ldcs_write_pipe(int fd, const void *data, int bytes );
-int _ldcs_read_pipe(int fd, void *data, int bytes, ldcs_read_block_t block );
+size_t _ldcs_write_pipe(int fd, const void *data, int bytes );
+size_t _ldcs_read_pipe(int fd, void *data, int bytes, ldcs_read_block_t block );
 
 typedef enum {
    LDCS_PIPE_FD_TYPE_SERVER,

--- a/src/logging/spindle_logd.cc
+++ b/src/logging/spindle_logd.cc
@@ -183,6 +183,7 @@ public:
 
    virtual void writeMessage(int proc, const char *msg1, int msg1_size, const char *msg2, int msg2_size)
    {
+      (void)proc;
       if (isExitCode(msg1, msg1_size, msg2, msg2_size)) {
          /* We've received the exitcode */
          shouldExit = true;
@@ -679,6 +680,7 @@ void cleanFiles()
 
 void on_sig(int sig)
 {
+   (void)sig;
    clean();
    exit(0);
 }

--- a/src/server/auditserver/cleanup_proc.cc
+++ b/src/server/auditserver/cleanup_proc.cc
@@ -42,6 +42,7 @@ static bool hit_sigterm = false;
 
 static void on_sigterm(int sig)
 {
+   (void)sig;
    hit_sigterm = true;   
 }
 

--- a/src/server/auditserver/force_exit.c
+++ b/src/server/auditserver/force_exit.c
@@ -102,6 +102,7 @@ int getForceExitFd()
 extern int set_exit_on_client_close(ldcs_process_data_t *procdata);
 int forceExitCB(int fd, int serverid, void *data)
 {
+   (void)serverid;
    char c;
    int result;
    ldcs_process_data_t *procdata = (ldcs_process_data_t *) data;

--- a/src/server/auditserver/ldcs_audit_server_handlers.c
+++ b/src/server/auditserver/ldcs_audit_server_handlers.c
@@ -263,7 +263,7 @@ static int handle_client_dirlists_req(ldcs_process_data_t *procdata, int nc)
    len += sizeof(ee_len);
    memcpy(buffer + len, procdata->exec_excludes, ee_len);
    len += ee_len;
-   assert(len == msg.header.len);
+   assert((size_t)len == msg.header.len);
    msg.data = buffer;
    
    ldcs_send_msg(connid, &msg);
@@ -1071,7 +1071,7 @@ static int handle_broadcast_errorcode(ldcs_process_data_t *procdata, char *pathn
    size_t packet_size = 0;
    int result;
    int pathname_len = strlen(pathname)+1;
-   int pos = 0;
+   size_t pos = 0;
    ldcs_message_t msg;
    double starttime;
    
@@ -1533,7 +1533,8 @@ static int handle_send_file_query(ldcs_process_data_t *procdata, char *fullpath,
 static int handle_file_errcode(ldcs_process_data_t *procdata, ldcs_message_t *msg, node_peer_t peer, broadcast_t bcast)
 {
    char *pathname;
-   int errcode, pathname_len, result, pos = 0;
+   int errcode, result, pathname_len;
+   size_t pos = 0;
    unsigned char *data;
 
    data = (unsigned char *) msg->data;
@@ -2024,8 +2025,8 @@ int handle_client_end(ldcs_process_data_t *procdata, int nc)
 
 static int handle_preload_filelist(ldcs_process_data_t *procdata, ldcs_message_t *msg)
 {
-   int cur = 0, global_result = 0, result;
-   int num_dirs, num_files, i;
+   size_t cur = 0;
+   int num_dirs, num_files, i, global_result = 0, result;
    char *data = (char *) msg->data;
    char *pathname;
    
@@ -2499,12 +2500,11 @@ static int handle_cache_ldso(ldcs_process_data_t *procdata, char *pathname, int 
 static int handle_broadcast_metadata(ldcs_process_data_t *procdata, char *pathname, int file_exists, unsigned char *buf, size_t buf_size, metadata_t mdtype)
 {
    char *packet_buffer = NULL;
-   size_t packet_size;
+   size_t packet_size, pos = 0;
    double starttime;
    int result;
    ldcs_message_t msg;
    int pathname_len = strlen(pathname) + 1;
-   int pos = 0;
    extended_stat_t *sbuf = (extended_stat_t *) buf;
    const char *mount;
    int mount_len;
@@ -2583,11 +2583,12 @@ static int handle_broadcast_metadata(ldcs_process_data_t *procdata, char *pathna
  **/
 static int handle_metadata_recv(ldcs_process_data_t *procdata, ldcs_message_t *msg, metadata_t mdtype, node_peer_t peer)
 {
-   int file_exists;
+   int file_exists, result;
    char pathname[MAX_PATH_LEN+1], *localpath;
    extended_stat_t buf;
    ldso_info_t ldsoinfo;
-   int pos = 0, pathlen, result, payload_size = 0, mount_len = 0, bytes_left;
+   size_t pos = 0, bytes_left;
+   int mount_len = 0, pathlen, payload_size = 0;
    char *buffer = (char *) msg->data;
    unsigned char *payload = NULL;
    char mount[MAX_PATH_LEN+1];
@@ -2599,11 +2600,11 @@ static int handle_metadata_recv(ldcs_process_data_t *procdata, ldcs_message_t *m
 
    memcpy(&pathlen, buffer + pos, sizeof(int));
    pos += sizeof(int);
-   assert(pathlen >= 0 && pathlen <= MAX_PATH_LEN);
+   assert(pathlen <= MAX_PATH_LEN);
 
    memcpy(&mount_len, buffer + pos, sizeof(int));
    pos += sizeof(int);
-   assert(mount_len >= 0 && mount_len <= MAX_PATH_LEN);
+   assert(mount_len <= MAX_PATH_LEN);
    
    memcpy(pathname, buffer + pos, pathlen);
    pos += pathlen;

--- a/src/server/auditserver/ldcs_audit_server_handlers.c
+++ b/src/server/auditserver/ldcs_audit_server_handlers.c
@@ -278,6 +278,7 @@ static int handle_client_dirlists_req(ldcs_process_data_t *procdata, int nc)
  **/
 static int handle_client_myrankinfo_msg(ldcs_process_data_t *procdata, int nc, ldcs_message_t *msg)
 {
+   (void)msg;
    int tmpdata[4];
    ldcs_message_t out_msg;
    int connid;
@@ -890,6 +891,7 @@ static int handle_finish_buffer_setup(ldcs_process_data_t *procdata, char *local
  **/
 static int handle_setup_alias(ldcs_process_data_t *procdata, char *pathname, char *alias_to)
 {
+   (void)procdata;
    char filename[MAX_PATH_LEN+1], dirname[MAX_PATH_LEN+1];
    char *localname;
    int errcode;
@@ -1532,6 +1534,8 @@ static int handle_send_file_query(ldcs_process_data_t *procdata, char *fullpath,
  **/
 static int handle_file_errcode(ldcs_process_data_t *procdata, ldcs_message_t *msg, node_peer_t peer, broadcast_t bcast)
 {
+   (void)peer;
+   (void)bcast;
    char *pathname;
    int errcode, result, pathname_len;
    size_t pos = 0;
@@ -1667,6 +1671,7 @@ static int handle_directory_recv(ldcs_process_data_t *procdata, ldcs_message_t *
  **/
 static int handle_alias_recv(ldcs_process_data_t *procdata, ldcs_message_t *msg, broadcast_t bcast)
 {
+   (void)bcast;
    char *alias_from, *alias_to;
    char *data;
    size_t from_size;
@@ -1994,6 +1999,7 @@ int handle_server_message(ldcs_process_data_t *procdata, node_peer_t peer, ldcs_
  **/
 int handle_client_start(ldcs_process_data_t *procdata, int nc)
 {
+   (void)nc;
    if (procdata->sent_exit_ready) {
       return handle_send_exit_cancel(procdata);
    }
@@ -2583,6 +2589,7 @@ static int handle_broadcast_metadata(ldcs_process_data_t *procdata, char *pathna
  **/
 static int handle_metadata_recv(ldcs_process_data_t *procdata, ldcs_message_t *msg, metadata_t mdtype, node_peer_t peer)
 {
+   (void)peer;
    int file_exists, result;
    char pathname[MAX_PATH_LEN+1], *localpath;
    extended_stat_t buf;
@@ -3065,6 +3072,7 @@ static int handle_send_exit_ready_if_done(ldcs_process_data_t *procdata)
  **/
 static int handle_exit_ready_msg(ldcs_process_data_t *procdata, ldcs_message_t *msg)
 {
+   (void)msg;
    debug_printf2("Got exit ready message\n");
    procdata->exit_readys_recvd++;
    return handle_send_exit_ready_if_done(procdata);
@@ -3077,6 +3085,7 @@ static int handle_exit_ready_msg(ldcs_process_data_t *procdata, ldcs_message_t *
  **/
 static int handle_exit_cancel_msg(ldcs_process_data_t *procdata, ldcs_message_t *msg)
 {
+   (void)msg;
    debug_printf2("Got exit cancel\n");
    assert(procdata->exit_readys_recvd > 0);
    procdata->exit_readys_recvd--;
@@ -3130,6 +3139,7 @@ static int handle_close_client_query(ldcs_process_data_t *procdata, int nc)
  **/
 int exit_note_cb(int fd, int serverid, void *data)
 {
+   (void)serverid;
    int result;
    ldcs_process_data_t *procdata = (ldcs_process_data_t *) data;
    int eresult = 0;

--- a/src/server/auditserver/ldcs_audit_server_handlers.c
+++ b/src/server/auditserver/ldcs_audit_server_handlers.c
@@ -1440,7 +1440,8 @@ static int handle_request_file(ldcs_process_data_t *procdata, node_peer_t from, 
       case REQ_DIRECTORY:
          dir_result = handle_send_query(procdata, dirname, 1, 0);
          add_requestor(procdata->file_requests, dirname, from);
-         /* Fall through to next case and request file */
+         /* Fall through */
+         /* to next case and request file */
       case REQ_FILE:
          result = handle_send_query(procdata, pathname, 0, is_dso);
          add_requestor(requestor_list, pathname, from);

--- a/src/server/auditserver/ldcs_audit_server_md_cobo.c
+++ b/src/server/auditserver/ldcs_audit_server_md_cobo.c
@@ -81,9 +81,8 @@ int ldcs_audit_server_md_init(unsigned int port, unsigned int num_ports,
                               unique_id_t unique_id, ldcs_process_data_t *data)
 {
    int rc=0;
-   unsigned int *portlist;
+   unsigned int *portlist, i;
    int my_rank, ranks, fanout;
-   int i;
 
    portlist = malloc(sizeof(unsigned int) * (num_ports + 1));
    for (i = 0; i < num_ports; i++) {

--- a/src/server/auditserver/ldcs_audit_server_md_cobo.c
+++ b/src/server/auditserver/ldcs_audit_server_md_cobo.c
@@ -169,6 +169,7 @@ int ldcs_audit_server_md_unregister_fd ( ldcs_process_data_t *ldcs_process_data 
 int ldcs_audit_server_md_destroy ( ldcs_process_data_t *ldcs_process_data ) 
 {
    /* Nothing to be done.  Sockets will be closed when we exit. */
+   (void)ldcs_process_data;
    if (cobo_close() != COBO_SUCCESS) {
       debug_printf3("Failed to close\n");
    }
@@ -282,6 +283,7 @@ int ldcs_audit_server_md_is_parent(node_peer_t peer)
 
 int ldcs_audit_server_md_cobo_CB(int fd, int nc, void *data)
 {
+   (void)nc;
    int rc=0;
    ldcs_process_data_t *ldcs_process_data = ( ldcs_process_data_t *) data ;
    ldcs_message_t msg;
@@ -309,6 +311,7 @@ int ldcs_audit_server_md_cobo_CB(int fd, int nc, void *data)
 
 int ldcs_audit_server_md_send(ldcs_process_data_t *ldcs_process_data, ldcs_message_t *msg, node_peer_t peer)
 {
+   (void)ldcs_process_data;
    int fd = (int) (long) peer;
    return write_msg(fd, msg);
 }
@@ -351,6 +354,7 @@ int ldcs_audit_server_md_send_noncontig(ldcs_process_data_t *ldcs_process_data, 
 
 int ldcs_audit_server_md_broadcast(ldcs_process_data_t *ldcs_process_data, ldcs_message_t *msg)
 {
+   (void)ldcs_process_data;
    int fd, i;
    int result, global_result = 0;
    int num_childs = 0;
@@ -392,6 +396,7 @@ int ldcs_audit_server_md_broadcast_noncontig(ldcs_process_data_t *ldcs_process_d
 
 int ldcs_audit_server_md_get_num_children(ldcs_process_data_t *procdata)
 {
+   (void)procdata;
    int num_childs = 0;
    cobo_get_num_childs(&num_childs);
    return num_childs;

--- a/src/server/auditserver/ldcs_audit_server_numa.c
+++ b/src/server/auditserver/ldcs_audit_server_numa.c
@@ -51,7 +51,7 @@ static int initialize_numa_lib() {
    char buffer[MAX_PATH_LEN+1];                    \
    char *end;                                      \
    char *start = colon_seperated_list;             \
-   int str_len;                                    \
+   size_t str_len;                                 \
    while (*start != '\0') {                        \
      while (*start == ':') {                       \
        start++;                                    \
@@ -77,7 +77,7 @@ static int initialize_numa_lib() {
    start = end;                                 \
    } 
 
-static int pattern_match(char *pattern, char *filename, int filename_len) {
+static int pattern_match(char *pattern, char *filename, size_t filename_len) {
    int should_match_at_start = 0, should_match_at_end = 0;
    size_t pattern_len = strlen(pattern);
    if (pattern[0] == '^') {

--- a/src/server/auditserver/ldcs_audit_server_process.c
+++ b/src/server/auditserver/ldcs_audit_server_process.c
@@ -47,6 +47,7 @@ ldcs_process_data_t ldcs_process_data;
 unsigned int opts;
 
 int _listen_exit_loop_cb_func ( int num_fds,  void * data) {
+  (void)num_fds;
   int rc=0;
   ldcs_process_data_t *ldcs_process_data = ( ldcs_process_data_t *) data ;
 

--- a/src/server/auditserver/ldcs_audit_server_process.h
+++ b/src/server/auditserver/ldcs_audit_server_process.h
@@ -106,7 +106,7 @@ typedef struct ldcs_client_struct ldcs_client_t;
 
 typedef struct msgbundle_entry_t {
    unsigned char *cache;
-   int position;
+   size_t position;
    void* node;
    struct msgbundle_entry_t *next;
    char name[16];
@@ -133,7 +133,7 @@ struct ldcs_process_data_struct
   char *numa_substrs;
   char *numa_excludes;   
   msgbundle_entry_t *msgbundle_entries;
-  int msgbundle_cache_size_kb;
+  size_t msgbundle_cache_size_kb;
   int msgbundle_timeout_ms;
   int handling_bundle;
   number_t number;

--- a/src/server/auditserver/ldcs_audit_server_requestors.c
+++ b/src/server/auditserver/ldcs_audit_server_requestors.c
@@ -21,7 +21,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 struct requested_file_struct
 {
    char *path;
-   int hash_val;
+   unsigned int hash_val;
    int requestors_num;
    int requestors_size;
    node_peer_t *requestors;

--- a/src/server/auditserver/ldcs_audit_server_server_cb.c
+++ b/src/server/auditserver/ldcs_audit_server_server_cb.c
@@ -27,6 +27,7 @@
 #include "ldcs_audit_server_handlers.h"
 
 int _ldcs_server_CB ( int infd, int serverid, void *data ) {
+   (void)infd;
    int rc=0;
    ldcs_process_data_t *ldcs_process_data = (ldcs_process_data_t *) data ;
    int nc, fd, more_avail;

--- a/src/server/auditserver/ldcs_elf_read.c
+++ b/src/server/auditserver/ldcs_elf_read.c
@@ -31,11 +31,7 @@ static int readUpTo(FILE *f, unsigned char *buffer, size_t *cur_pos, size_t new_
    if (*cur_pos >= new_size)
       return 0;
 
-   do {
-      result = fread(buffer + *cur_pos, 1, new_size - *cur_pos, f);
-   } while (result == -1 && errno == EINTR);
-   if (result == -1)
-      return -1;
+   result = fread(buffer + *cur_pos, 1, new_size - *cur_pos, f);
    *cur_pos += result;
    return 0;
 }

--- a/src/server/auditserver/msgbundle.c
+++ b/src/server/auditserver/msgbundle.c
@@ -54,6 +54,7 @@ void msgbundle_init(ldcs_process_data_t *procdata)
 
 void msgbundle_done(ldcs_process_data_t *procdata)
 {   
+   (void)procdata;
    void *retval;
    if (!initialized)
       return;
@@ -173,6 +174,7 @@ static int flush_msgbuffer(msgbundle_entry_t *mb, ldcs_process_data_t *procdata)
 
 static int flush_msgbuffer_cb(int fd, int serverid, void *data)
 {
+   (void)serverid;
    msgbundle_entry_t *mb;
    ldcs_process_data_t *procdata = (ldcs_process_data_t *) data;
    char throwaway_byte;
@@ -201,6 +203,8 @@ void msgbundle_force_flush(ldcs_process_data_t *procdata)
 
 static void start_cache_timeout(int timeout_ms, ldcs_process_data_t *procdata)
 {
+   (void)timeout_ms;
+   (void)procdata;
    pthread_mutex_lock(&mut);
 
    if (!active_timeout) {

--- a/src/server/auditserver/msgbundle.c
+++ b/src/server/auditserver/msgbundle.c
@@ -38,7 +38,7 @@ void msgbundle_init(ldcs_process_data_t *procdata)
    assert(procdata->msgbundle_cache_size_kb);
    assert(procdata->msgbundle_timeout_ms);
    procdata->msgbundle_entries = NULL;
-   debug_printf("Initializing message bundling with buffer of size %u kb and "
+   debug_printf("Initializing message bundling with buffer of size %zu kb and "
                 "send timeout of %u ms\n", procdata->msgbundle_cache_size_kb,
                 procdata->msgbundle_timeout_ms);
 
@@ -234,7 +234,7 @@ int spindle_send_worker(ldcs_process_data_t *procdata, ldcs_message_t *msg, node
        procdata->msgbundle_cache_size_kb*1024)
    {
       debug_printf2("Not using message bundling because packet size (%ld) is greater than"
-                    "cache size %d.\n",
+                    "cache size %zu.\n",
                     sizeof(msg->header)*2 + msg->header.len,
                     procdata->msgbundle_cache_size_kb*1024);
       if (mb)
@@ -269,7 +269,7 @@ int spindle_send_worker(ldcs_process_data_t *procdata, ldcs_message_t *msg, node
        procdata->msgbundle_cache_size_kb*1024)
    {
       debug_printf2("Flushing message buffer due to no space for adding new message."
-                    "Current size = %u, new message size = %lu, capacity = %u\n",
+                    "Current size = %zu, new message size = %zu, capacity = %zu\n",
                     mb->position,
                     sizeof(msg->header) + msg->header.len,
                     procdata->msgbundle_cache_size_kb*1024);
@@ -280,7 +280,7 @@ int spindle_send_worker(ldcs_process_data_t *procdata, ldcs_message_t *msg, node
       debug_printf2("Starting new message buffer\n");
    }
    else {
-      debug_printf2("Appending message at position %d\n", mb->position);
+      debug_printf2("Appending message at position %zu\n", mb->position);
    }
 
    memcpy(mb->cache + mb->position, &msg->header, sizeof(ldcs_message_header_t));
@@ -291,8 +291,8 @@ int spindle_send_worker(ldcs_process_data_t *procdata, ldcs_message_t *msg, node
       memcpy(mb->cache + mb->position, secondary_data, secondary_size);
       mb->position += secondary_size;
    }
-   debug_printf2("Cached data in message buffer to node %s, which is %u of %u bytes full.\n",
-                 mb->name, (int) mb->position, procdata->msgbundle_cache_size_kb*1024);
+   debug_printf2("Cached data in message buffer to node %s, which is %zu of %zu bytes full.\n",
+                 mb->name, mb->position, procdata->msgbundle_cache_size_kb*1024);
 
    start_cache_timeout(procdata->msgbundle_timeout_ms, procdata);
    return 0;

--- a/src/server/cache/global_name.c
+++ b/src/server/cache/global_name.c
@@ -63,8 +63,8 @@ void grow_global_name_list()
 static int get_global_file_index(char* file)
 {
   char buf[MAX_PATH_LEN+1];
-  int len = strlen(file);
-  int cnt;
+  size_t len = strlen(file);
+  size_t cnt;
   int rval;
   int val;
 

--- a/src/server/comlib/ldcs_api_biter.c
+++ b/src/server/comlib/ldcs_api_biter.c
@@ -67,6 +67,7 @@ int ldcs_create_server_biter(char* location, number_t num)
 
 int ldcs_open_server_connection_biter(int id)
 {
+   (void)id;
    assert(0 && "Unused");
    return -1;
 }
@@ -246,6 +247,7 @@ int ldcs_socket_id_to_nc_biter(int id, int fd, ldcs_process_data_t *process_data
 
 int ldcs_recv_msg_static_biter(int connid, ldcs_message_t *msg, ldcs_read_block_t block)
 {
+   (void)block;
    int session = CLIENT_ID_SESSION(connid);
    int proc = CLIENT_ID_PROC(connid);
    int result;

--- a/src/server/comlib/ldcs_api_pipe.c
+++ b/src/server/comlib/ldcs_api_pipe.c
@@ -101,6 +101,7 @@ int ldcs_get_fd_pipe (int fd) {
 extern int spindle_mkdir(char *orig_path);
 
 int ldcs_create_server_pipe(char* location, number_t number) {
+  (void)number;
   int fd;
 
   fd=get_new_fd_pipe();
@@ -138,10 +139,12 @@ int ldcs_create_server_pipe(char* location, number_t number) {
 
 int ldcs_open_server_connection_pipe(int fd) {
   /*  */
+  (void)fd;
   return(-1);
 }
 
 int ldcs_open_server_connections_pipe(int fd, int nc, int *more_avail) {
+  (void)nc;
   int  fifoid, inout, connfd;
   char fifo[MAX_PATH_LEN];
   char *fifo_file;
@@ -431,5 +434,7 @@ int ldcs_get_aux_fd_pipe()
 
 int ldcs_socket_id_to_nc_pipe(int id, int fd, ldcs_process_data_t *process_data)
 {
+   (void)fd;
+   (void)process_data;
    return id;
 }

--- a/src/server/comlib/ldcs_api_pipe.c
+++ b/src/server/comlib/ldcs_api_pipe.c
@@ -270,7 +270,7 @@ int ldcs_destroy_server_pipe(int fd) {
 /* ************************************************************** */
 int ldcs_send_msg_pipe(int fd, ldcs_message_t * msg) {
 
-  int n;
+  size_t n;
 
   if ((fd<0) || (fd>fdlist_pipe_size) )  _error("wrong fd");
   
@@ -279,11 +279,9 @@ int ldcs_send_msg_pipe(int fd, ldcs_message_t * msg) {
 	       msg->header.len,msg->data );  
 
   n = _ldcs_write_pipe(fdlist_pipe[fd].out_fd,&msg->header,sizeof(msg->header));
-  if (n < 0) _error("ERROR writing header to pipe");
 
   if(msg->header.len>0) {
     n = _ldcs_write_pipe(fdlist_pipe[fd].out_fd,(void *) msg->data,msg->header.len);
-    if (n < 0) _error("ERROR writing data to pipe");
     if (n != msg->header.len) _error("sent different number of bytes for message data");
   }
     
@@ -292,7 +290,7 @@ int ldcs_send_msg_pipe(int fd, ldcs_message_t * msg) {
 
 ldcs_message_t * ldcs_recv_msg_pipe(int fd, ldcs_read_block_t block ) {
   ldcs_message_t *msg;
-  int n;
+  size_t n;
 
   if ((fd<0) || (fd>fdlist_pipe_size) )  _error("wrong fd");
 
@@ -304,7 +302,6 @@ ldcs_message_t * ldcs_recv_msg_pipe(int fd, ldcs_read_block_t block ) {
     free(msg);
     return(NULL);
   }
-  if (n < 0) _error("ERROR reading header from connection");
 
   if(msg->header.len>0) {
 
@@ -312,7 +309,6 @@ ldcs_message_t * ldcs_recv_msg_pipe(int fd, ldcs_read_block_t block ) {
     if (!msg)  _error("could not allocate memory for message data");
 
     n = _ldcs_read_pipe(fdlist_pipe[fd].in_fd,msg->data,msg->header.len, LDCS_READ_BLOCK);
-    if (n < 0) _error("ERROR reading message data from socket");
     if (n != msg->header.len) _error("received different number of bytes for message data");
 
   } else {
@@ -327,7 +323,7 @@ ldcs_message_t * ldcs_recv_msg_pipe(int fd, ldcs_read_block_t block ) {
 }
 
 int ldcs_recv_msg_static_pipe(int fd, ldcs_message_t *msg, ldcs_read_block_t block) {
-  int n;
+  size_t n;
   int rc=0;
   msg->header.type=LDCS_MSG_UNKNOWN;
   msg->header.len=0;
@@ -342,17 +338,11 @@ int ldcs_recv_msg_static_pipe(int fd, ldcs_message_t *msg, ldcs_read_block_t blo
      msg->data = NULL;
      return(rc);
   }
-  if (n < 0) _error("ERROR reading header from connection");
 
   if(msg->header.len>0) {
     n = _ldcs_read_pipe(fdlist_pipe[fd].in_fd,msg->data,msg->header.len, LDCS_READ_BLOCK);
     if (n == 0) 
        return(rc);
-    if (n < 0) {
-       int error = errno;
-       err_printf("Error during read of pipe: %s (%d)\n", strerror(error), error);
-       return -1;
-    }
     if (n != msg->header.len) {
        int error = errno;
        err_printf("Partial read on pipe.  Got %u / %u: %s (%d)\n",
@@ -372,9 +362,10 @@ int ldcs_recv_msg_static_pipe(int fd, ldcs_message_t *msg, ldcs_read_block_t blo
   return(rc);
 }
 
-int _ldcs_read_pipe(int fd, void *data, int bytes, ldcs_read_block_t block ) {
+size_t _ldcs_read_pipe(int fd, void *data, int bytes, ldcs_read_block_t block ) {
 
-  int         left,bsumread;
+  int         left;
+  size_t      bsumread;
   ssize_t     btoread, bread;
   char       *dataptr;
   int print_count = 512;
@@ -414,9 +405,9 @@ int _ldcs_read_pipe(int fd, void *data, int bytes, ldcs_read_block_t block ) {
 
 
 
-int _ldcs_write_pipe(int fd, const void *data, int bytes ) {
-  int         left,bsumwrote;
-  ssize_t     bwrite, bwrote;
+size_t _ldcs_write_pipe(int fd, const void *data, int bytes ) {
+  size_t      bsumwrote;
+  ssize_t     bwrite, bwrote, left;
   char       *dataptr;
   
   left      = bytes;

--- a/src/server/comlib/ldcs_api_socket.c
+++ b/src/server/comlib/ldcs_api_socket.c
@@ -183,10 +183,9 @@ int ldcs_destroy_server_socket(int fd) {
 /* ************************************************************** */
 /* message transfer functions                                     */
 /* ************************************************************** */
-static int _ldcs_read_socket(int fd, void *data, int bytes, ldcs_read_block_t block) {
+static size_t _ldcs_read_socket(int fd, void *data, int bytes, ldcs_read_block_t block) {
 
-  int         left,bsumread;
-  ssize_t      btoread, bread;
+  ssize_t    btoread, bread, left, bsumread;
   char       *dataptr;
   
   left      = bytes;
@@ -266,7 +265,8 @@ int ldcs_send_msg_socket(int fd, ldcs_message_t * msg) {
 ldcs_message_t * ldcs_recv_msg_socket(int fd,  ldcs_read_block_t block) {
   ldcs_message_t *msg;
   char help[41];
-  int n, connfd;
+  size_t n;
+  int connfd;
   if ((fd<0) || (fd>MAX_FD) )  _error("wrong fd");
   connfd=ldcs_socket_fdlist[fd].fd;
 
@@ -279,7 +279,6 @@ ldcs_message_t * ldcs_recv_msg_socket(int fd,  ldcs_read_block_t block) {
     free(msg);
     return(NULL);
   }
-  if (n < 0) _error("ERROR reading header from socket");
 
   if(msg->header.len>0) {
 
@@ -287,7 +286,6 @@ ldcs_message_t * ldcs_recv_msg_socket(int fd,  ldcs_read_block_t block) {
     if (!msg)  _error("could not allocate memory for message data");
     
     n = _ldcs_read_socket(connfd,msg->data,msg->header.len, LDCS_READ_BLOCK);
-    if (n < 0) _error("ERROR reading message data from socket");
     if (n != msg->header.len) _error("received different number of bytes for message data");
 
   } else {
@@ -305,15 +303,14 @@ ldcs_message_t * ldcs_recv_msg_socket(int fd,  ldcs_read_block_t block) {
 
 int ldcs_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_t block) {
   char help[41];
-  int rc=0;
-  int n, connfd;
+  int rc=0, connfd;
+  size_t n;
   if ((fd<0) || (fd>MAX_FD) )  _error("wrong fd");
   connfd=ldcs_socket_fdlist[fd].fd;
 
 
   n = _ldcs_read_socket(connfd,&msg->header,sizeof(msg->header), block);
   if (n == 0) return(rc);
-  if (n < 0) _error("ERROR reading header from socket");
 
   if(msg->header.len>0) {
 
@@ -322,7 +319,6 @@ int ldcs_recv_msg_static_socket(int fd, ldcs_message_t *msg,  ldcs_read_block_t 
     
     n = _ldcs_read_socket(connfd,msg->data,msg->header.len, LDCS_READ_BLOCK);
     if (n == 0) return(rc);
-    if (n < 0) _error("ERROR reading message data from socket");
     if (n != msg->header.len) _error("received different number of bytes for message data");
 
   } else {

--- a/src/server/comlib/ldcs_api_socket.c
+++ b/src/server/comlib/ldcs_api_socket.c
@@ -84,6 +84,7 @@ int ldcs_get_fd_socket (int fd) {
 
 
 int ldcs_create_server_socket(char* location, number_t number) {
+  (void)location;
   int fd, sockfd;
   struct sockaddr_in serv_addr;
 
@@ -157,6 +158,7 @@ int ldcs_open_server_connection_socket(int fd) {
 };
 
 int ldcs_open_server_connections_socket(int fd, int nc, int *more_avail) {
+  (void)nc;
   *more_avail=0;
   return(ldcs_open_server_connection_socket(fd));
 };
@@ -340,5 +342,7 @@ int ldcs_get_aux_fd_socket()
 
 int ldcs_socket_id_to_nc_socket(int id, int fd, ldcs_process_data_t *process_data)
 {
+   (void)fd;
+   (void)process_data;
    return id;
 }

--- a/src/utils/exitnote.c
+++ b/src/utils/exitnote.c
@@ -56,10 +56,10 @@ static char *exitSocketPath(const char *location)
       endslash = "/";
 
    result = snprintf(socketpath, sizeof(socketpath), "%s%sspindle_bext_%s", location, endslash, hostname);
-   if (result > sizeof(socketpath)) {
+   if (result > (int)sizeof(socketpath)) {
       snprintf(socketpath, sizeof(socketpath), "%s%s%x", location, endslash, badhash(hostname));
    }
-   if (result > sizeof(socketpath)) {
+   if (result > (int)sizeof(socketpath)) {
       err_printf("Could not fit socket path %s%sspindle_bext_%s into max socket path of %lu\n",
                  location, endslash, hostname, (unsigned long) sizeof(socketpath));
       return NULL;

--- a/src/utils/fileutil.c
+++ b/src/utils/fileutil.c
@@ -26,9 +26,9 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 int read_n_bytes(char *localname, int fd, void *buffer, size_t size)
 {
-   int result, bytes_read, error;
-   bytes_read = 0;
-   debug_printf3("Reading %ld bytes from %s\n", size, localname);
+   int result, error;
+   size_t bytes_read = 0;
+   debug_printf3("Reading %zu bytes from %s\n", size, localname);
 
    while (bytes_read != size) {
       errno = 0;
@@ -37,7 +37,7 @@ int read_n_bytes(char *localname, int fd, void *buffer, size_t size)
          error = errno;
          if (error == EAGAIN || error == EINTR)
             continue;
-         err_printf("Failed to read from file %s of size %lu (already read %d): %s\n",
+         err_printf("Failed to read from file %s of size %zu (already read %zu): %s\n",
                     localname, size, bytes_read, strerror(error));
          close(fd);
          return -1;
@@ -77,7 +77,8 @@ int read_buffer(char *localname, char *buffer, int size)
 
 int write_n_bytes(char *localname, int fd, void *buffer, size_t size)
 {
-   int result, bytes_written;
+   int result;
+   size_t bytes_written;
 
    bytes_written = 0;
 

--- a/src/utils/keyfile.c
+++ b/src/utils/keyfile.c
@@ -45,6 +45,9 @@ void get_keyfile_path(char *pathname, int pathname_len, uint64_t unique_id)
    snprintf(pathname, pathname_len, "%s/spindle_key.%d.%lu", demangled_loc, getuid(), (unsigned long) unique_id);
    pathname[pathname_len-1] = '\0';
 #else
+   (void)pathname;
+   (void)pathname_len;
+   (void)unique_id;
    assert(0 && "Tried to use keyfile when not compiled with keyfile.");
 #endif
 }

--- a/src/utils/keyfile.c
+++ b/src/utils/keyfile.c
@@ -80,7 +80,7 @@ void create_keyfile(uint64_t unique_id)
 {
    char path[MAX_PATH_LEN+1];
    int key_fd, result;
-   int bytes_written;
+   size_t bytes_written;
    char *last_slash;
    struct stat buf;
    unsigned char key[KEY_SIZE_BYTES];

--- a/src/utils/parseloc.c
+++ b/src/utils/parseloc.c
@@ -223,13 +223,13 @@ char **parse_colonsep_prefixes(char *colonsep_list, number_t number)
       prefixes[0] = NULL;
       return prefixes;
    }
-   int numprefixes = 1;
+   size_t numprefixes = 1;
    for (size_t i = 0; s[i] != '\0'; i++) {
       if (s[i] == ':') {
          numprefixes++;
       }
    }   
-   int num_strs = numprefixes + 1;
+   size_t num_strs = numprefixes + 1;
    
    prefixes = (char **) malloc(sizeof(char*) * num_strs);
    size_t i = 0, cur = 0;

--- a/src/utils/pathfn.c
+++ b/src/utils/pathfn.c
@@ -24,7 +24,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 int addCWDToDir(pid_t pid, char *dir, int result_size)
 {
-   int cwd_len, dir_len, i, result;
+   int cwd_len, dir_len, result;
    char cwd[MAX_PATH_LEN+1];
    char cwd_loc[64];
    
@@ -55,10 +55,9 @@ int addCWDToDir(pid_t pid, char *dir, int result_size)
       return 0;
    }
 
-   for (i = dir_len; i >= 0; i--)
-      dir[i + cwd_len + 1] = dir[i];
-   dir[cwd_len] = '/';
-   strncpy(dir, cwd, cwd_len);
+   char *dir2 = strdup( dir );
+   snprintf( dir, result_size, "%s/%s", cwd, dir2 );
+   free(dir2);
    return 0;
 }
 

--- a/testsuite/spindle_exec_test.c
+++ b/testsuite/spindle_exec_test.c
@@ -255,6 +255,8 @@ void setuppath()
 
 int main(int argc, char *argv[])
 {
+   (void)argc;
+   (void)argv;
    setuppath();
    runtest(set_true, e_execl);
    runtest(set_true, e_execlp);

--- a/testsuite/symbind_test.c
+++ b/testsuite/symbind_test.c
@@ -307,7 +307,7 @@ void *runtest_for_lib(const char *libname, int options)
       { "fxstat", "fstat", libspindle, NULL, NULL, 0 },
       { "lxstat", "lstat", libspindle, NULL, NULL, 0 },
       { "xstat", "stat", libspindle, NULL, NULL, 0 },
-      { NULL, NULL, NULL, NULL, 0 }
+      { NULL, NULL, NULL, NULL, NULL, 0 }
    };
 
    if (options & TDL_NO_STAT) {

--- a/testsuite/symbind_test.c
+++ b/testsuite/symbind_test.c
@@ -51,6 +51,7 @@ int verbose = 0;
 
 static int get_phdr_for_cb(struct dl_phdr_info *info, size_t size, void *data)
 {
+   (void)size;
    get_phdr_for_t *params;
 
    params = (get_phdr_for_t *) data;
@@ -92,6 +93,7 @@ typedef struct {
 
 static int check_dso_cb(struct dl_phdr_info *info, size_t size, void *data)
 {
+   (void)size;
    find_dso_t *params;
    int i;
    ElfW(Addr) addr, start, end;


### PR DESCRIPTION
Fixes and updates to compile under gcc 15.1.0 with the flags `-Wall`, `-Wextra`, and `-Werror`.

Commits are based on the class of errors/warnings rather than files.

```
commit 47cb39:  Fixes three errors caused by stricter gcc defaults.
commit c6f85d:  Fixes one [-Wdiscarded-qualifiers] and one [-Wstringop-truncation].
commit a7260c:  Fixes fallthrough and initialization warnings.
commit acc263:  Fixes -Wsign-compare warnings.
commit 5182e8:  Fixes -Wformat warnings.
commit 32d0c6:  Suppresses -Wunused-parameter warnings by casting to void.
```
Fixes #94 