### PR TITLE
Fixes for glibc bug around locale and TLS crashes

### DIFF
--- a/config.h.in
+++ b/config.h.in
@@ -85,6 +85,9 @@
    */
 #undef LT_OBJDIR
 
+/* Defined if GLIBC has locale TLS bug */
+#undef NEWTHREAD_LOCALE_BUG
+
 /* Exclusions for numa optimization */
 #undef NUMA_EXCLUDES
 

--- a/configure
+++ b/configure
@@ -16747,7 +16747,7 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for glibc dtv allocation bug" >&5
 $as_echo_n "checking for glibc dtv allocation bug... " >&6; }
-if test "x`${SPINDLE_SOURCE_ROOT}/scripts/dtvtest/run_dtvtest.sh ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest ${SPINDLE_BUILD_ROOT}/dtvtest '$CC' '$CFLAGS'`" == "x0"; then
+if ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest/run_dtvtest.sh ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest ${SPINDLE_BUILD_ROOT}/dtvtest '$CC' '$CFLAGS'; then
    DTV_ALLOC_BUG=0
    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
@@ -16760,6 +16760,24 @@ fi
 cat >>confdefs.h <<_ACEOF
 #define DTV_ALLOCATION_BUG $DTV_ALLOC_BUG
 _ACEOF
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for locale tls fault glibc bug" >&5
+$as_echo_n "checking for locale tls fault glibc bug... " >&6; }
+if ${SPINDLE_SOURCE_ROOT}/scripts/locale_tls_fault/tls_locale_fault.sh ${SPINDLE_SOURCE_ROOT}/scripts/locale_tls_fault ${SPINDLE_BUILD_ROOT}/locale_tls_fault $CC; then
+   LOCALE_FAULT_BUG=0
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+else
+   LOCALE_FAULT_BUG=1
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define NEWTHREAD_LOCALE_BUG $LOCALE_FAULT_BUG
+_ACEOF
+
 
 
 #OS Detection

--- a/configure.common.ac
+++ b/configure.common.ac
@@ -87,7 +87,7 @@ fi
 AM_CONDITIONAL([BLD_FLUXPLUGIN], [test "x$ENABLE_FLUX_PLUGIN" = "xtrue"])
 
 AC_MSG_CHECKING([for glibc dtv allocation bug])
-if test "x`${SPINDLE_SOURCE_ROOT}/scripts/dtvtest/run_dtvtest.sh ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest ${SPINDLE_BUILD_ROOT}/dtvtest '$CC' '$CFLAGS'`" == "x0"; then
+if ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest/run_dtvtest.sh ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest ${SPINDLE_BUILD_ROOT}/dtvtest '$CC' '$CFLAGS'; then
    DTV_ALLOC_BUG=0
    AC_MSG_RESULT([no])
 else
@@ -95,6 +95,17 @@ else
    AC_MSG_RESULT([yes])
 fi
 AC_DEFINE_UNQUOTED([DTV_ALLOCATION_BUG],[$DTV_ALLOC_BUG],[Defined if GLIBC has an allocation bug])
+
+AC_MSG_CHECKING([for locale tls fault glibc bug])
+if ${SPINDLE_SOURCE_ROOT}/scripts/locale_tls_fault/tls_locale_fault.sh ${SPINDLE_SOURCE_ROOT}/scripts/locale_tls_fault ${SPINDLE_BUILD_ROOT}/locale_tls_fault $CC; then
+   LOCALE_FAULT_BUG=0
+   AC_MSG_RESULT([no])
+else
+   LOCALE_FAULT_BUG=1
+   AC_MSG_RESULT([yes])
+fi
+AC_DEFINE_UNQUOTED([NEWTHREAD_LOCALE_BUG],[$LOCALE_FAULT_BUG],[Defined if GLIBC has locale TLS bug])
+
 
 #OS Detection
 AC_ARG_ENABLE(bluegene,

--- a/scripts/dtvtest/Makefile
+++ b/scripts/dtvtest/Makefile
@@ -1,5 +1,5 @@
-DEP_NUMS = 01 02 03 04 05 06 07 08 09 10 11 12 13
-DLOPEN_NUMS = 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15
+DEP_NUMS = 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18
+DLOPEN_NUMS = 01 02 03 04 05 06 07 08 09 10 11 12 13 14 15 16 17 18
 
 DEP_LIBS = $(DEP_NUMS:%=libdeptls%.so)
 DEP_LINKS = $(DEP_NUMS:%=-ldeptls%)
@@ -23,9 +23,8 @@ libminaudit.so: $(SRCDIR)/minaudit.c
 	gcc -shared -fPIC -o $@ $<
 
 dtvtest: $(SRCDIR)/dtvtest.c $(DEP_LIBS)
-	gcc -o $@ $(SRCDIR)/dtvtest.c -ldl -lpthread -g -Wl,-rpath,`pwd` -L`pwd` $(DEP_LINKS)
+	gcc -o $@ $(SRCDIR)/dtvtest.c -ldl -lpthread -g -Wl,-rpath,`pwd` -L`pwd` -Wl,--no-as-needed -Wl,--disable-new-dtags $(DEP_LINKS)
 
 run: dtvtest libminaudit.so $(DLOPEN_LIBS)
-	echo LD_AUDIT=./libminaudit.so ./dtvtest $(DLOPEN_NUMS)
 	LD_AUDIT=./libminaudit.so ./dtvtest $(DLOPEN_NUMS)
-	echo $?
+	@echo $$?

--- a/scripts/locale_tls_fault/app.c
+++ b/scripts/locale_tls_fault/app.c
@@ -1,0 +1,39 @@
+#include <pthread.h>
+#include <stdio.h>
+#include <dlfcn.h>
+#include <stdlib.h>
+#include <signal.h>
+
+void onsig(int sig)
+{
+   exit(-1);
+}
+
+void *thrdrun(void *arg)
+{
+   void *result;
+
+   //Any audit-triggering operation will do
+   result = dlopen("libm.so.6", RTLD_NOW);
+   if (!result) {
+      return NULL;
+   }
+
+   return NULL;
+}
+
+int main(int argc, char *argv[])
+{
+   pthread_t thrd;
+   int result;
+
+   signal(SIGSEGV, onsig);
+   
+   result = pthread_create(&thrd, NULL, thrdrun, NULL);
+   if (result != 0) {
+      return -1;
+   }
+
+   pthread_join(thrd, NULL);
+   return 0;
+}

--- a/scripts/locale_tls_fault/auditor.c
+++ b/scripts/locale_tls_fault/auditor.c
@@ -1,0 +1,22 @@
+#define _GNU_SOURCE
+#include <link.h>
+#include <stdio.h>
+#include <string.h>
+
+extern int isspace(int c);
+
+unsigned int la_version(unsigned int v)
+{
+   return LAV_CURRENT;
+}
+
+unsigned int la_objopen(struct link_map *map, Lmid_t lmid, uintptr_t *cookie)
+{
+   //Need something that accesses TLS through R_X86_64_TPOFF64, which
+   //isspace does by getting the locale
+   int result;
+   if (strstr(map->l_name, "libm.so")) {
+      result = isspace(' ');
+   }
+   return 0;
+}

--- a/scripts/locale_tls_fault/tls_locale_fault.sh
+++ b/scripts/locale_tls_fault/tls_locale_fault.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+TEST_SRCDIR=$1
+TEST_BUILDDIR=$2
+COMPILE=$3
+
+mkdir -p $TEST_BUILDDIR
+$COMPILE -o $TEST_BUILDDIR/localeapp $TEST_SRCDIR/app.c -ldl -lpthread
+$COMPILE -shared -fPIC -o $TEST_BUILDDIR/liblocaleaudit.so $TEST_SRCDIR/auditor.c
+LD_AUDIT=$TEST_BUILDDIR/liblocaleaudit.so $TEST_BUILDDIR/localeapp
+

--- a/src/client/auditclient/Makefile.am
+++ b/src/client/auditclient/Makefile.am
@@ -14,7 +14,7 @@ AM_CFLAGS = -fvisibility=hidden
 
 AM_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/client -I$(top_srcdir)/client_comlib
 
-BASE_SRCS = auditclient.c auditclient_common.c patch_linkmap.c redirect.c bindgot.c writablegot.c patch_bad_dtv.c
+BASE_SRCS = auditclient.c auditclient_common.c patch_linkmap.c redirect.c bindgot.c writablegot.c patch_bad_dtv.c malloc_wrapper.c fixlocale.c
 if X86_64_BLD
 ARCH_SRCS = auditclient_x86_64.c 
 endif

--- a/src/client/auditclient/Makefile.in
+++ b/src/client/auditclient/Makefile.in
@@ -143,10 +143,11 @@ libspindle_audit_biter_la_DEPENDENCIES =  \
 	$(top_builddir)/client/libspindlec_biter.la $(AUDITLIB)
 am__libspindle_audit_biter_la_SOURCES_DIST = auditclient.c \
 	auditclient_common.c patch_linkmap.c redirect.c bindgot.c \
-	writablegot.c patch_bad_dtv.c auditclient_aarch64.c \
-	auditclient_ppc64.c auditclient_x86_64.c
+	writablegot.c patch_bad_dtv.c malloc_wrapper.c fixlocale.c \
+	auditclient_aarch64.c auditclient_ppc64.c auditclient_x86_64.c
 am__objects_1 = auditclient.lo auditclient_common.lo patch_linkmap.lo \
-	redirect.lo bindgot.lo writablegot.lo patch_bad_dtv.lo
+	redirect.lo bindgot.lo writablegot.lo patch_bad_dtv.lo \
+	malloc_wrapper.lo fixlocale.lo
 @AARCH64_BLD_FALSE@@PPC64LE_BLD_FALSE@@PPC64_BLD_FALSE@@X86_64_BLD_TRUE@am__objects_2 = auditclient_x86_64.lo
 @AARCH64_BLD_FALSE@@PPC64LE_BLD_FALSE@@PPC64_BLD_TRUE@am__objects_2 = auditclient_ppc64.lo
 @AARCH64_BLD_FALSE@@PPC64LE_BLD_TRUE@am__objects_2 =  \
@@ -169,8 +170,8 @@ libspindle_audit_pipe_la_DEPENDENCIES =  \
 	$(top_builddir)/client/libspindlec_pipe.la $(AUDITLIB)
 am__libspindle_audit_pipe_la_SOURCES_DIST = auditclient.c \
 	auditclient_common.c patch_linkmap.c redirect.c bindgot.c \
-	writablegot.c patch_bad_dtv.c auditclient_aarch64.c \
-	auditclient_ppc64.c auditclient_x86_64.c
+	writablegot.c patch_bad_dtv.c malloc_wrapper.c fixlocale.c \
+	auditclient_aarch64.c auditclient_ppc64.c auditclient_x86_64.c
 am_libspindle_audit_pipe_la_OBJECTS = $(am__objects_1) \
 	$(am__objects_2)
 libspindle_audit_pipe_la_OBJECTS =  \
@@ -184,8 +185,8 @@ libspindle_audit_socket_la_DEPENDENCIES =  \
 	$(top_builddir)/client/libspindlec_socket.la $(AUDITLIB)
 am__libspindle_audit_socket_la_SOURCES_DIST = auditclient.c \
 	auditclient_common.c patch_linkmap.c redirect.c bindgot.c \
-	writablegot.c patch_bad_dtv.c auditclient_aarch64.c \
-	auditclient_ppc64.c auditclient_x86_64.c
+	writablegot.c patch_bad_dtv.c malloc_wrapper.c fixlocale.c \
+	auditclient_aarch64.c auditclient_ppc64.c auditclient_x86_64.c
 am_libspindle_audit_socket_la_OBJECTS = $(am__objects_1) \
 	$(am__objects_2)
 libspindle_audit_socket_la_OBJECTS =  \
@@ -216,6 +217,7 @@ am__depfiles_remade = ./$(DEPDIR)/auditclient.Plo \
 	./$(DEPDIR)/auditclient_common.Plo \
 	./$(DEPDIR)/auditclient_ppc64.Plo \
 	./$(DEPDIR)/auditclient_x86_64.Plo ./$(DEPDIR)/bindgot.Plo \
+	./$(DEPDIR)/fixlocale.Plo ./$(DEPDIR)/malloc_wrapper.Plo \
 	./$(DEPDIR)/patch_bad_dtv.Plo ./$(DEPDIR)/patch_linkmap.Plo \
 	./$(DEPDIR)/redirect.Plo ./$(DEPDIR)/writablegot.Plo
 am__mv = mv -f
@@ -407,7 +409,7 @@ top_srcdir = @top_srcdir@
 pkglib_LTLIBRARIES = $(am__append_1) $(am__append_2) $(am__append_3)
 AM_CFLAGS = -fvisibility=hidden
 AM_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/client -I$(top_srcdir)/client_comlib
-BASE_SRCS = auditclient.c auditclient_common.c patch_linkmap.c redirect.c bindgot.c writablegot.c patch_bad_dtv.c
+BASE_SRCS = auditclient.c auditclient_common.c patch_linkmap.c redirect.c bindgot.c writablegot.c patch_bad_dtv.c malloc_wrapper.c fixlocale.c
 @AARCH64_BLD_TRUE@ARCH_SRCS = auditclient_aarch64.c
 @PPC64LE_BLD_TRUE@ARCH_SRCS = auditclient_ppc64.c
 @PPC64_BLD_TRUE@ARCH_SRCS = auditclient_ppc64.c
@@ -512,6 +514,8 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/auditclient_ppc64.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/auditclient_x86_64.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/bindgot.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/fixlocale.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/malloc_wrapper.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/patch_bad_dtv.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/patch_linkmap.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/redirect.Plo@am__quote@ # am--include-marker
@@ -687,6 +691,8 @@ distclean: distclean-am
 	-rm -f ./$(DEPDIR)/auditclient_ppc64.Plo
 	-rm -f ./$(DEPDIR)/auditclient_x86_64.Plo
 	-rm -f ./$(DEPDIR)/bindgot.Plo
+	-rm -f ./$(DEPDIR)/fixlocale.Plo
+	-rm -f ./$(DEPDIR)/malloc_wrapper.Plo
 	-rm -f ./$(DEPDIR)/patch_bad_dtv.Plo
 	-rm -f ./$(DEPDIR)/patch_linkmap.Plo
 	-rm -f ./$(DEPDIR)/redirect.Plo
@@ -742,6 +748,8 @@ maintainer-clean: maintainer-clean-am
 	-rm -f ./$(DEPDIR)/auditclient_ppc64.Plo
 	-rm -f ./$(DEPDIR)/auditclient_x86_64.Plo
 	-rm -f ./$(DEPDIR)/bindgot.Plo
+	-rm -f ./$(DEPDIR)/fixlocale.Plo
+	-rm -f ./$(DEPDIR)/malloc_wrapper.Plo
 	-rm -f ./$(DEPDIR)/patch_bad_dtv.Plo
 	-rm -f ./$(DEPDIR)/patch_linkmap.Plo
 	-rm -f ./$(DEPDIR)/redirect.Plo

--- a/src/client/auditclient/fixlocale.c
+++ b/src/client/auditclient/fixlocale.c
@@ -1,0 +1,59 @@
+/*
+This file is part of Spindle.  For copyright information see the COPYRIGHT 
+file in the top level directory, or at 
+https://github.com/hpc/Spindle/blob/master/COPYRIGHT
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License (as published by the Free Software
+Foundation) version 2.1 dated February 1999.  This program is distributed in the
+hope that it will be useful, but WITHOUT ANY WARRANTY; without even the IMPLIED
+WARRANTY OF MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms 
+and conditions of the GNU Lesser General Public License for more details.  You should 
+have received a copy of the GNU Lesser General Public License along with this 
+program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#include <locale.h>
+#include <unistd.h>
+
+#include "spindle_debug.h"
+#include "config.h"
+
+#if defined(NEWTHREAD_LOCALE_BUG)
+#include <sys/syscall.h>
+
+static __thread int fixed_locale = 0;
+
+static pid_t gettid()
+{
+   return syscall(SYS_gettid);   
+}
+
+#endif
+
+/**
+ * This works around the LD_AUDIT bug documented at:
+ *  https://sourceware.org/bugzilla/show_bug.cgi?id=32483
+ *
+ * We need to set the locale for app-space created threads in the audit space.
+ * Otherwise we see seg faults under malloc in spindle when malloc calls
+ * get_nprocs.
+ **/
+void check_for_new_thread()
+{
+#if defined(NEWTHREAD_LOCALE_BUG)
+   locale_t l;
+   if (fixed_locale)
+      return;
+   fixed_locale = 1;
+   if (gettid() == getpid()) {
+      debug_printf3("Primary thread. Not updating locale.\n");      
+      return;
+   }
+
+   debug_printf2("Identified new thread. Fixing locale\n");
+   l = uselocale((locale_t) 0);
+   uselocale(l);
+#endif
+}

--- a/src/client/auditclient/fixlocale.h
+++ b/src/client/auditclient/fixlocale.h
@@ -1,0 +1,22 @@
+/*
+This file is part of Spindle.  For copyright information see the COPYRIGHT 
+file in the top level directory, or at 
+https://github.com/hpc/Spindle/blob/master/COPYRIGHT
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License (as published by the Free Software
+Foundation) version 2.1 dated February 1999.  This program is distributed in the
+hope that it will be useful, but WITHOUT ANY WARRANTY; without even the IMPLIED
+WARRANTY OF MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms 
+and conditions of the GNU Lesser General Public License for more details.  You should 
+have received a copy of the GNU Lesser General Public License along with this 
+program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+#if !defined(FIXLOCALE_H_)
+#define FIXLOCALE_H_
+
+void check_for_new_thread();
+
+#endif

--- a/src/client/auditclient/malloc_wrapper.c
+++ b/src/client/auditclient/malloc_wrapper.c
@@ -1,0 +1,315 @@
+/*
+This file is part of Spindle.  For copyright information see the COPYRIGHT 
+file in the top level directory, or at 
+https://github.com/hpc/Spindle/blob/master/COPYRIGHT
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License (as published by the Free Software
+Foundation) version 2.1 dated February 1999.  This program is distributed in the
+hope that it will be useful, but WITHOUT ANY WARRANTY; without even the IMPLIED
+WARRANTY OF MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the terms 
+and conditions of the GNU Lesser General Public License for more details.  You should 
+have received a copy of the GNU Lesser General Public License along with this 
+program; if not, write to the Free Software Foundation, Inc., 59 Temple
+Place, Suite 330, Boston, MA 02111-1307 USA
+*/
+
+
+//Tune these #defines to enable heap debugging
+//#define HEAP_DEBUGGING_ENABLED
+//#define CHECK_MEM
+//#define REDZONE
+//#define REDZONE_L
+//#define CHECK_ALL
+
+#ifdef HEAP_DEBUGGING_ENABLED
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <execinfo.h>
+#include <sys/mman.h>
+
+extern void *__libc_malloc(size_t);
+extern void __libc_free(void *);
+extern void *__libc_realloc(void *, size_t);
+extern void *__libc_calloc(size_t nmemb, size_t size);
+
+#define AUDIT_EXPORT __attribute__((__visibility__("default")))
+void *malloc(size_t size) AUDIT_EXPORT;
+void free(void *ptr) AUDIT_EXPORT;
+void *realloc(void *ptr, size_t newsize) AUDIT_EXPORT;
+void *calloc(size_t nmemb, size_t size) AUDIT_EXPORT;
+
+#define HEADER 0xfe6a99423cc650f1
+#define FOOTER 0xda4481c3c421ab65
+
+
+#ifdef CHECK_MEM
+static unsigned int count = 0;
+
+static int should_print(int c) {
+   return 0;
+   //   return (c < 100 || c > 4000 || c % 100 == 0);
+}
+static void *mark_up_malloc(void *result, size_t size, int is_calloc)
+{
+   unsigned long *header, *footer, *sizep;
+   sizep = (unsigned long *) result;
+   header = ((unsigned long *) result) + 1;
+   footer = (unsigned long *) (((unsigned char *) result) + 16 + size);
+   *sizep = size;
+   *header = HEADER;
+   *footer = FOOTER;
+   void *uresult = (void *) (((unsigned long *) result) + 2);
+   if (should_print(count))
+      fprintf(stderr, "%u. %s(%lu) = %p (%p)\n",
+              count, is_calloc ? "calloc" : "malloc",
+              size, uresult, result);
+   count++;
+   return uresult;
+}
+
+static ssize_t check(void *result, int is_free)
+{
+   unsigned long *header, *footer, *sizep;
+   size_t size;
+   unsigned long *resultp = (((unsigned long *) result) - 2);
+
+   sizep = resultp;
+   header = resultp+1;
+   size = *sizep;
+   footer = (unsigned long *) (((unsigned char *) resultp) + 16 + size);   
+
+   if (*header != HEADER) {
+      fprintf(stderr, "CORRUPT HEADER on %p\n", result);
+   }
+   if (*footer != FOOTER) {
+      fprintf(stderr, "CORRUPT FOOTER on %p\n", result);
+   }
+   if (*header != HEADER || *footer != FOOTER) {
+      return -1;
+   }  
+
+   if (is_free)
+      memset(resultp, 0xac, size + 24);
+   return size;
+}
+#endif
+
+#define PAGE_SIZE 4096
+#if defined(REDZONE) || defined(CHECK_ALL)
+static void *page_alloc(size_t size)
+{
+   void *result;
+   int iresult;
+   size_t rsize;
+#if defined(REDZONE_L) || defined(REDZONE_R)
+   while (size % 16 != 0) size++;
+   rsize = size + PAGE_SIZE;
+#else
+   rsize = size;
+#endif
+   result = mmap(NULL, rsize, PROT_READ|PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+   if (result == MAP_FAILED) {
+      fprintf(stderr, "[MMAP FAILED DURING ALLOC]\n");
+      return NULL;
+   }
+#if defined(REDZONE_L)
+   iresult = mprotect(result, PAGE_SIZE, PROT_NONE);
+   if (iresult == -1) {
+      printf("mprotect failed\n");
+      return NULL;
+   }
+   return (void *) (((unsigned char *) result) + PAGE_SIZE);
+#elif defined(REDZONE_R)
+   unsigned long last_page_addr = ((unsigned long) result) + rsize;
+   unsigned long last_page = last_page_addr & ~(PAGE_SIZE - 1);
+   if (last_page_addr == last_page)
+      last_page = last_page_addr - PAGE_SIZE;
+   iresult = mprotect((void*) last_page, 4096, PROT_NONE);
+   if (iresult == -1) {
+      printf("mprotect failed\n");
+      return NULL;
+   }
+   unsigned char *cur = result;
+   while (cur + size != (unsigned char*) last_page) cur++;
+   return (void *) cur;
+#else
+   return result;
+#endif
+   
+}
+#endif
+#if defined(REDZONE)
+static void page_free(void *mem, size_t size) {
+   int result;
+   unsigned long addr = (unsigned long) mem;
+   addr &= ~(PAGE_SIZE - 1);
+   result = mprotect((void *) addr, size, PROT_NONE);
+   if (result == -1) {
+      printf("mprotect error\n");
+   }
+}
+#endif
+
+#if defined(CHECK_ALL)
+#define NUM_BUFFERS 4096
+#define BUFFER_SIZE 131072
+static void** all_buffers[4096];
+
+void check_all(void *ptr)
+{
+   unsigned int i, j;
+   unsigned int num_checked = 0;
+   void **found = NULL;
+   for (i = 0; i < NUM_BUFFERS && all_buffers[i]; i++) {
+      void **cur_buffer = all_buffers[i];
+      for (j = 0; j < BUFFER_SIZE; j++) {
+         if (!cur_buffer[j])
+            continue;
+         if (cur_buffer[j] == ptr) {
+            if (found) {
+               fprintf(stderr, "[CHECK ALL ERROR - Ptr %p found twice in buffer list]\n", ptr);               
+            }
+            found = cur_buffer + j;
+         }
+         num_checked++;
+         check(cur_buffer[j], 0);
+      }
+   }
+   if (found)
+      *found = NULL;
+   if (should_print(count))
+      fprintf(stderr, "Checked %u live allocs\n", num_checked);
+   
+}
+
+void add_to_check_all(void *ptr)
+{
+   static int errd = 0;
+   unsigned int i, j;
+   for (i = 0; i < NUM_BUFFERS; i++) {
+      void **cur_buffer = all_buffers[i];
+      if (cur_buffer == NULL) {
+         all_buffers[i] = page_alloc(BUFFER_SIZE * sizeof(void*));
+         all_buffers[i][0] = ptr;
+         return;
+      }
+      for (j = 0; j < BUFFER_SIZE; j++) {
+         if (!cur_buffer[j]) {
+            cur_buffer[j] = ptr;
+            return;
+         }
+      }
+   }
+   if (!errd) {
+      fprintf(stderr, "[CHECK ALL ERROR - Buffer list full\n]");
+      errd = 1;
+   }
+}
+
+#endif
+
+void *malloc(size_t size)
+{
+   void *result;
+#ifdef CHECK_MEM
+# ifdef CHECK_ALL
+   check_all(NULL);
+# endif   
+# ifdef REDZONE
+   result = page_alloc(size + 24);
+# else
+   if (should_print(count))
+      fprintf(stderr, "%u. malloc start(%lu)\n", count, size);
+   result = __libc_malloc(size + 24);
+# endif
+   result = mark_up_malloc(result, size, 0);
+# ifdef CHECK_ALL
+   add_to_check_all(result);
+# endif
+#else
+   result = __libc_malloc(size);
+#endif
+   
+   return result;
+}
+
+void free(void *ptr) {
+#ifdef CHECK_MEM
+   ssize_t result;
+# ifdef CHECK_ALL
+   check_all(ptr);
+# endif   
+   if (should_print(count))
+      fprintf(stderr, "%u. free(%p)\n", count, ptr);  
+   if (!ptr)
+      return;
+   result = check(ptr, 1);
+   if (result == -1) {
+      __libc_free(ptr);
+      return;
+   }
+
+# ifdef REDZONE
+   page_free(((unsigned char *) ptr) - 16, result + 24);
+# else
+   __libc_free(((unsigned char *) ptr) - 16);
+# endif
+#else
+   __libc_free(((unsigned char *) ptr));   
+#endif   
+}
+
+void *realloc(void *ptr, size_t newsize)
+{
+#ifdef CHECK_MEM
+   void *newbuf;
+   ssize_t result;
+
+   if (!ptr) {
+      void *mresult = malloc(newsize);
+      if (should_print(count))   
+         fprintf(stderr, "%u. realloc(%p, %lu) = %p\n", count, ptr, newsize, mresult);
+      return mresult;
+   }
+   if (ptr && !newsize) {
+      if (should_print(count))   
+         fprintf(stderr, "%u. realloc(%p, %lu) = %p\n", count, ptr, newsize, NULL);      
+      free(ptr);
+      return NULL;
+   }
+      
+   result = check(ptr, 0);
+   if (result == -1) {
+      return __libc_realloc(ptr, newsize);
+   }
+   newbuf = malloc(newsize);
+   memcpy(newbuf, ptr, result);
+   if (should_print(count))   
+      fprintf(stderr, "realloc(%p, %lu) = %p\n", ptr, newsize, newbuf);
+   free(ptr);
+   return newbuf;
+#else
+   return __libc_realloc(ptr, newsize);
+#endif
+}
+
+void *calloc(size_t nmemb, size_t size) {
+#ifdef CHECK_MEM
+   void *newptr;
+# if defined(REDZONE)
+   newptr = page_alloc((nmemb * size) + 24);
+# else
+   newptr = __libc_malloc((nmemb * size) + 24);
+#endif
+   newptr = mark_up_malloc(newptr, nmemb * size, 1);
+   memset(newptr, 0, nmemb * size);
+   return newptr;
+#else
+   return __libc_calloc(nmemb, size);
+#endif
+}
+
+#endif

--- a/src/client/client/Makefile.am
+++ b/src/client/client/Makefile.am
@@ -13,7 +13,7 @@ endif
 
 AM_CFLAGS = -fvisibility=hidden
 
-AM_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/../include -I$(top_srcdir)/shm_cache -I$(top_srcdir)/subaudit -I$(top_srcdir)/../utils
+AM_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/../include -I$(top_srcdir)/shm_cache -I$(top_srcdir)/subaudit -I$(top_srcdir)/../utils  -I$(top_srcdir)/auditclient
 
 INTERCEPT_SRCS = intercept_open.c intercept_exec.c intercept_stat.c intercept_readlink.c intercept_spindleapi.c intercept.c spindle_regex.c patch_interception.c realpath.c $(top_srcdir)/../utils/fileutil.c
 
@@ -29,7 +29,7 @@ libspindlec_biter_la_SOURCES = $(BASE_SRCS)
 libspindlec_biter_la_LIBADD = $(top_builddir)/client_comlib/libclient_biter.la $(top_builddir)/logging/libspindleclogc.la $(top_builddir)/shm_cache/libshmcache.la
 
 libspindle_audit_la_SOURCES = $(INTERCEPT_SRCS)
-libspindle_audit_la_CPPFLAGS = -DAUDIT_LIB -I$(top_srcdir)/auditclient $(AM_CPPFLAGS)
+libspindle_audit_la_CPPFLAGS = -DAUDIT_LIB $(AM_CPPFLAGS)
 
 #libspindle_instr_la_SOURCES = $(INTERCEPT_SRCS)
 #libspindle_instr_la_CPPFLAGS = -DINSTR_LIB -I$(top_srcdir)/instrclient $(AM_CPPFLAGS)

--- a/src/client/client/Makefile.in
+++ b/src/client/client/Makefile.in
@@ -374,7 +374,7 @@ top_srcdir = @top_srcdir@
 noinst_LTLIBRARIES = libspindle_audit.la $(am__append_1) \
 	$(am__append_2) $(am__append_3)
 AM_CFLAGS = -fvisibility=hidden
-AM_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/../include -I$(top_srcdir)/shm_cache -I$(top_srcdir)/subaudit -I$(top_srcdir)/../utils
+AM_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/client_comlib -I$(top_srcdir)/../include -I$(top_srcdir)/shm_cache -I$(top_srcdir)/subaudit -I$(top_srcdir)/../utils  -I$(top_srcdir)/auditclient
 INTERCEPT_SRCS = intercept_open.c intercept_exec.c intercept_stat.c intercept_readlink.c intercept_spindleapi.c intercept.c spindle_regex.c patch_interception.c realpath.c $(top_srcdir)/../utils/fileutil.c
 BASE_SRCS = client.c lookup.c should_intercept.c exec_util.c remap_exec.c lookup_libc.c $(top_srcdir)/../utils/parseloc.c $(top_srcdir)/../utils/getcpu.c 
 libspindlec_socket_la_SOURCES = $(BASE_SRCS)
@@ -384,7 +384,7 @@ libspindlec_pipe_la_LIBADD = $(top_builddir)/client_comlib/libclient_pipe.la $(t
 libspindlec_biter_la_SOURCES = $(BASE_SRCS)
 libspindlec_biter_la_LIBADD = $(top_builddir)/client_comlib/libclient_biter.la $(top_builddir)/logging/libspindleclogc.la $(top_builddir)/shm_cache/libshmcache.la
 libspindle_audit_la_SOURCES = $(INTERCEPT_SRCS)
-libspindle_audit_la_CPPFLAGS = -DAUDIT_LIB -I$(top_srcdir)/auditclient $(AM_CPPFLAGS)
+libspindle_audit_la_CPPFLAGS = -DAUDIT_LIB $(AM_CPPFLAGS)
 all: all-am
 
 .SUFFIXES:

--- a/src/client/client/client.c
+++ b/src/client/client/client.c
@@ -40,6 +40,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "ccwarns.h"
 #include "exec_util.h"
 #include "intercept.h"
+#include "fixlocale.h"
 
 errno_location_t app_errno_location;
 
@@ -286,6 +287,8 @@ static void reset_server_connection()
 void check_for_fork()
 {
    static int cached_pid = 0;
+   check_for_new_thread();
+   
    int current_pid = getpid();
    if (!cached_pid) {
       cached_pid = current_pid;
@@ -483,7 +486,7 @@ char *client_library_load(const char *name)
          // that shouldn't get relocated.
          //We'll leak this strdup memory for a path in that case. Oh well.
          debug_printf2("Warning. Accessing spindle cache location corresponding to non-cachable location: %s", orig_file_name);
-         return strdup(orig_file_name);
+         return spindle_strdup(orig_file_name);
       }
       return (char *) name;
    }

--- a/src/client/config.h.in
+++ b/src/client/config.h.in
@@ -76,6 +76,9 @@
    */
 #undef LT_OBJDIR
 
+/* Defined if GLIBC has locale TLS bug */
+#undef NEWTHREAD_LOCALE_BUG
+
 /* Exclusions for numa optimization */
 #undef NUMA_EXCLUDES
 

--- a/src/client/configure
+++ b/src/client/configure
@@ -12719,7 +12719,7 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for glibc dtv allocation bug" >&5
 $as_echo_n "checking for glibc dtv allocation bug... " >&6; }
-if test "x`${SPINDLE_SOURCE_ROOT}/scripts/dtvtest/run_dtvtest.sh ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest ${SPINDLE_BUILD_ROOT}/dtvtest '$CC' '$CFLAGS'`" == "x0"; then
+if ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest/run_dtvtest.sh ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest ${SPINDLE_BUILD_ROOT}/dtvtest '$CC' '$CFLAGS'; then
    DTV_ALLOC_BUG=0
    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
@@ -12732,6 +12732,24 @@ fi
 cat >>confdefs.h <<_ACEOF
 #define DTV_ALLOCATION_BUG $DTV_ALLOC_BUG
 _ACEOF
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for locale tls fault glibc bug" >&5
+$as_echo_n "checking for locale tls fault glibc bug... " >&6; }
+if ${SPINDLE_SOURCE_ROOT}/scripts/locale_tls_fault/tls_locale_fault.sh ${SPINDLE_SOURCE_ROOT}/scripts/locale_tls_fault ${SPINDLE_BUILD_ROOT}/locale_tls_fault $CC; then
+   LOCALE_FAULT_BUG=0
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+else
+   LOCALE_FAULT_BUG=1
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define NEWTHREAD_LOCALE_BUG $LOCALE_FAULT_BUG
+_ACEOF
+
 
 
 #OS Detection

--- a/src/client/subaudit/Makefile.am
+++ b/src/client/subaudit/Makefile.am
@@ -14,7 +14,7 @@ AM_CFLAGS = -fvisibility=hidden
 
 AM_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/client -I$(top_srcdir)/client_comlib -I$(top_srcdir)/auditclient -I$(top_srcdir)/../utils
 
-BASE_SRCS = subaudit.c intercept_malloc.c update_pltbind.c ../auditclient/auditclient_common.c ../auditclient/patch_linkmap.c
+BASE_SRCS = subaudit.c intercept_malloc.c update_pltbind.c ../auditclient/auditclient_common.c ../auditclient/patch_linkmap.c ../auditclient/fixlocale.c
 
 AUDITLIB = $(top_builddir)/client/libspindle_audit.la
 

--- a/src/client/subaudit/Makefile.in
+++ b/src/client/subaudit/Makefile.in
@@ -144,7 +144,7 @@ libspindle_subaudit_biter_la_DEPENDENCIES =  \
 am__dirstamp = $(am__leading_dot)dirstamp
 am__objects_1 = subaudit.lo intercept_malloc.lo update_pltbind.lo \
 	../auditclient/auditclient_common.lo \
-	../auditclient/patch_linkmap.lo
+	../auditclient/patch_linkmap.lo ../auditclient/fixlocale.lo
 am_libspindle_subaudit_biter_la_OBJECTS = $(am__objects_1)
 libspindle_subaudit_biter_la_OBJECTS =  \
 	$(am_libspindle_subaudit_biter_la_OBJECTS)
@@ -202,6 +202,7 @@ DEFAULT_INCLUDES = -I.@am__isrc@ -I$(top_builddir)
 depcomp = $(SHELL) $(top_srcdir)/../../scripts/depcomp
 am__maybe_remake_depfiles = depfiles
 am__depfiles_remade = ../auditclient/$(DEPDIR)/auditclient_common.Plo \
+	../auditclient/$(DEPDIR)/fixlocale.Plo \
 	../auditclient/$(DEPDIR)/patch_linkmap.Plo \
 	./$(DEPDIR)/intercept_malloc.Plo ./$(DEPDIR)/preloadlib.Plo \
 	./$(DEPDIR)/subaudit.Plo ./$(DEPDIR)/update_pltbind.Plo
@@ -397,7 +398,7 @@ pkglib_LTLIBRARIES = libspindleint.la $(am__append_1) $(am__append_2) \
 	$(am__append_3)
 AM_CFLAGS = -fvisibility=hidden
 AM_CPPFLAGS = -I$(top_srcdir)/../logging -I$(top_srcdir)/../include -I$(top_srcdir)/client -I$(top_srcdir)/client_comlib -I$(top_srcdir)/auditclient -I$(top_srcdir)/../utils
-BASE_SRCS = subaudit.c intercept_malloc.c update_pltbind.c ../auditclient/auditclient_common.c ../auditclient/patch_linkmap.c
+BASE_SRCS = subaudit.c intercept_malloc.c update_pltbind.c ../auditclient/auditclient_common.c ../auditclient/patch_linkmap.c ../auditclient/fixlocale.c
 AUDITLIB = $(top_builddir)/client/libspindle_audit.la
 libspindleint_la_SOURCES = preloadlib.c
 libspindleint_la_LDFLAGS = -shared -avoid-version
@@ -488,6 +489,8 @@ clean-pkglibLTLIBRARIES:
 	../auditclient/$(DEPDIR)/$(am__dirstamp)
 ../auditclient/patch_linkmap.lo: ../auditclient/$(am__dirstamp) \
 	../auditclient/$(DEPDIR)/$(am__dirstamp)
+../auditclient/fixlocale.lo: ../auditclient/$(am__dirstamp) \
+	../auditclient/$(DEPDIR)/$(am__dirstamp)
 
 libspindle_subaudit_biter.la: $(libspindle_subaudit_biter_la_OBJECTS) $(libspindle_subaudit_biter_la_DEPENDENCIES) $(EXTRA_libspindle_subaudit_biter_la_DEPENDENCIES) 
 	$(AM_V_CCLD)$(libspindle_subaudit_biter_la_LINK) $(am_libspindle_subaudit_biter_la_rpath) $(libspindle_subaudit_biter_la_OBJECTS) $(libspindle_subaudit_biter_la_LIBADD) $(LIBS)
@@ -510,6 +513,7 @@ distclean-compile:
 	-rm -f *.tab.c
 
 @AMDEP_TRUE@@am__include@ @am__quote@../auditclient/$(DEPDIR)/auditclient_common.Plo@am__quote@ # am--include-marker
+@AMDEP_TRUE@@am__include@ @am__quote@../auditclient/$(DEPDIR)/fixlocale.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@../auditclient/$(DEPDIR)/patch_linkmap.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/intercept_malloc.Plo@am__quote@ # am--include-marker
 @AMDEP_TRUE@@am__include@ @am__quote@./$(DEPDIR)/preloadlib.Plo@am__quote@ # am--include-marker
@@ -684,6 +688,7 @@ clean-am: clean-generic clean-libtool clean-pkglibLTLIBRARIES \
 
 distclean: distclean-am
 		-rm -f ../auditclient/$(DEPDIR)/auditclient_common.Plo
+	-rm -f ../auditclient/$(DEPDIR)/fixlocale.Plo
 	-rm -f ../auditclient/$(DEPDIR)/patch_linkmap.Plo
 	-rm -f ./$(DEPDIR)/intercept_malloc.Plo
 	-rm -f ./$(DEPDIR)/preloadlib.Plo
@@ -735,6 +740,7 @@ installcheck-am:
 
 maintainer-clean: maintainer-clean-am
 		-rm -f ../auditclient/$(DEPDIR)/auditclient_common.Plo
+	-rm -f ../auditclient/$(DEPDIR)/fixlocale.Plo
 	-rm -f ../auditclient/$(DEPDIR)/patch_linkmap.Plo
 	-rm -f ./$(DEPDIR)/intercept_malloc.Plo
 	-rm -f ./$(DEPDIR)/preloadlib.Plo

--- a/src/fe/config.h.in
+++ b/src/fe/config.h.in
@@ -115,6 +115,9 @@
 /* Use munge for authentication */
 #undef MUNGE
 
+/* Defined if GLIBC has locale TLS bug */
+#undef NEWTHREAD_LOCALE_BUG
+
 /* Exclusions for numa optimization */
 #undef NUMA_EXCLUDES
 

--- a/src/fe/configure
+++ b/src/fe/configure
@@ -16569,7 +16569,7 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for glibc dtv allocation bug" >&5
 $as_echo_n "checking for glibc dtv allocation bug... " >&6; }
-if test "x`${SPINDLE_SOURCE_ROOT}/scripts/dtvtest/run_dtvtest.sh ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest ${SPINDLE_BUILD_ROOT}/dtvtest '$CC' '$CFLAGS'`" == "x0"; then
+if ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest/run_dtvtest.sh ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest ${SPINDLE_BUILD_ROOT}/dtvtest '$CC' '$CFLAGS'; then
    DTV_ALLOC_BUG=0
    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
@@ -16582,6 +16582,24 @@ fi
 cat >>confdefs.h <<_ACEOF
 #define DTV_ALLOCATION_BUG $DTV_ALLOC_BUG
 _ACEOF
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for locale tls fault glibc bug" >&5
+$as_echo_n "checking for locale tls fault glibc bug... " >&6; }
+if ${SPINDLE_SOURCE_ROOT}/scripts/locale_tls_fault/tls_locale_fault.sh ${SPINDLE_SOURCE_ROOT}/scripts/locale_tls_fault ${SPINDLE_BUILD_ROOT}/locale_tls_fault $CC; then
+   LOCALE_FAULT_BUG=0
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+else
+   LOCALE_FAULT_BUG=1
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define NEWTHREAD_LOCALE_BUG $LOCALE_FAULT_BUG
+_ACEOF
+
 
 
 #OS Detection

--- a/src/server/config.h.in
+++ b/src/server/config.h.in
@@ -97,6 +97,9 @@
 /* Use munge for authentication */
 #undef MUNGE
 
+/* Defined if GLIBC has locale TLS bug */
+#undef NEWTHREAD_LOCALE_BUG
+
 /* Exclusions for numa optimization */
 #undef NUMA_EXCLUDES
 

--- a/src/server/configure
+++ b/src/server/configure
@@ -16566,7 +16566,7 @@ fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for glibc dtv allocation bug" >&5
 $as_echo_n "checking for glibc dtv allocation bug... " >&6; }
-if test "x`${SPINDLE_SOURCE_ROOT}/scripts/dtvtest/run_dtvtest.sh ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest ${SPINDLE_BUILD_ROOT}/dtvtest '$CC' '$CFLAGS'`" == "x0"; then
+if ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest/run_dtvtest.sh ${SPINDLE_SOURCE_ROOT}/scripts/dtvtest ${SPINDLE_BUILD_ROOT}/dtvtest '$CC' '$CFLAGS'; then
    DTV_ALLOC_BUG=0
    { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }
@@ -16579,6 +16579,24 @@ fi
 cat >>confdefs.h <<_ACEOF
 #define DTV_ALLOCATION_BUG $DTV_ALLOC_BUG
 _ACEOF
+
+
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for locale tls fault glibc bug" >&5
+$as_echo_n "checking for locale tls fault glibc bug... " >&6; }
+if ${SPINDLE_SOURCE_ROOT}/scripts/locale_tls_fault/tls_locale_fault.sh ${SPINDLE_SOURCE_ROOT}/scripts/locale_tls_fault ${SPINDLE_BUILD_ROOT}/locale_tls_fault $CC; then
+   LOCALE_FAULT_BUG=0
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+else
+   LOCALE_FAULT_BUG=1
+   { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+$as_echo "yes" >&6; }
+fi
+
+cat >>confdefs.h <<_ACEOF
+#define NEWTHREAD_LOCALE_BUG $LOCALE_FAULT_BUG
+_ACEOF
+
 
 
 #OS Detection

--- a/testsuite/Makefile.am
+++ b/testsuite/Makefile.am
@@ -15,12 +15,12 @@ libgenerator_SOURCES = libgenerator.c
 
 test_driverSOURCES = $(top_srcdir)/testsuite/test_driver.c
 test_driverCFLAGS = -DLPATH=$(top_builddir)/testsuite -I$(top_srcdir)/src/client/spindle_api -I$(top_srcdir)/src/utils $(MPI_CFLAGS) -Wall -I$(top_builddir)
-test_driverLDADD = -ldl -ltestoutput -lfuncdict -lspindle
+test_driverLDADD = -ldl -lpthread -ltestoutput -lfuncdict -lspindle
 test_driverLDFLAGS = -Wl,-E -L$(top_builddir)/testsuite -L$(top_builddir)/src/client/spindle_api $(MPI_CLDFLAGS) $(LDFLAGS) -L. $(DYNAMIC_FLAG) -no-install
 
 test_driver_libsSOURCES = $(top_srcdir)/testsuite/test_driver.c
 test_driver_libsCFLAGS = -DLPATH=$(top_builddir)/testsuite -I$(top_srcdir)/src/client/spindle_api -I$(top_srcdir)/src/utils $(MPI_CFLAGS) -Wall
-test_driver_libsLDADD = -ltest10 -ltest11 -ltest12 -ltest13 -ltest14 -ltest15 -ltest16 -ltest17 -ltest18 -ltest19 -ltest20 -ltest50 -ltest100 -ltest500 -ltest1000 -ltest2000 -ltest4000 -ltest6000 -ltest8000 -ltest10000 -ldepA -lcxxexceptA -loriginlib -ldl -ltestoutput -lfuncdict -ldepB -ldepC -lcxxexceptB -lspindle
+test_driver_libsLDADD = -ltest10 -ltest11 -ltest12 -ltest13 -ltest14 -ltest15 -ltest16 -ltest17 -ltest18 -ltest19 -ltest20 -ltest50 -ltest100 -ltest500 -ltest1000 -ltest2000 -ltest4000 -ltest6000 -ltest8000 -ltest10000 -ldepA -lcxxexceptA -loriginlib -ldl -lpthread -ltestoutput -lfuncdict -ldepB -ldepC -lcxxexceptB -lspindle
 test_driver_libsLDFLAGS = -Wl,-E -L$(top_builddir)/testsuite $(MPI_CLDFLAGS) -L$(top_builddir)/src/client/spindle_api -L. $(DYNAMIC_FLAG) -no-install $(LDFLAGS) -Wl,-rpath,$(PWD)/origin_dir -L$(PWD)/origin_dir -Wl,-rpath-link,$(PWD)/origin_dir/origin_subdir -I$(top_builddir)
 
 REGLIB_SRC = $(srcdir)/registerlib.c

--- a/testsuite/Makefile.in
+++ b/testsuite/Makefile.in
@@ -363,11 +363,11 @@ BUILT_SOURCES = libtest10.so libtest11.so libtest12.so libtest13.so \
 libgenerator_SOURCES = libgenerator.c
 test_driverSOURCES = $(top_srcdir)/testsuite/test_driver.c
 test_driverCFLAGS = -DLPATH=$(top_builddir)/testsuite -I$(top_srcdir)/src/client/spindle_api -I$(top_srcdir)/src/utils $(MPI_CFLAGS) -Wall -I$(top_builddir)
-test_driverLDADD = -ldl -ltestoutput -lfuncdict -lspindle
+test_driverLDADD = -ldl -lpthread -ltestoutput -lfuncdict -lspindle
 test_driverLDFLAGS = -Wl,-E -L$(top_builddir)/testsuite -L$(top_builddir)/src/client/spindle_api $(MPI_CLDFLAGS) $(LDFLAGS) -L. $(DYNAMIC_FLAG) -no-install
 test_driver_libsSOURCES = $(top_srcdir)/testsuite/test_driver.c
 test_driver_libsCFLAGS = -DLPATH=$(top_builddir)/testsuite -I$(top_srcdir)/src/client/spindle_api -I$(top_srcdir)/src/utils $(MPI_CFLAGS) -Wall
-test_driver_libsLDADD = -ltest10 -ltest11 -ltest12 -ltest13 -ltest14 -ltest15 -ltest16 -ltest17 -ltest18 -ltest19 -ltest20 -ltest50 -ltest100 -ltest500 -ltest1000 -ltest2000 -ltest4000 -ltest6000 -ltest8000 -ltest10000 -ldepA -lcxxexceptA -loriginlib -ldl -ltestoutput -lfuncdict -ldepB -ldepC -lcxxexceptB -lspindle
+test_driver_libsLDADD = -ltest10 -ltest11 -ltest12 -ltest13 -ltest14 -ltest15 -ltest16 -ltest17 -ltest18 -ltest19 -ltest20 -ltest50 -ltest100 -ltest500 -ltest1000 -ltest2000 -ltest4000 -ltest6000 -ltest8000 -ltest10000 -ldepA -lcxxexceptA -loriginlib -ldl -lpthread -ltestoutput -lfuncdict -ldepB -ldepC -lcxxexceptB -lspindle
 test_driver_libsLDFLAGS = -Wl,-E -L$(top_builddir)/testsuite $(MPI_CLDFLAGS) -L$(top_builddir)/src/client/spindle_api -L. $(DYNAMIC_FLAG) -no-install $(LDFLAGS) -Wl,-rpath,$(PWD)/origin_dir -L$(PWD)/origin_dir -Wl,-rpath-link,$(PWD)/origin_dir/origin_subdir -I$(top_builddir)
 REGLIB_SRC = $(srcdir)/registerlib.c
 LD_FUNCDICT = -L$(top_builddir)/testsuite -lfuncdict

--- a/testsuite/runTests_template
+++ b/testsuite/runTests_template
@@ -12,6 +12,8 @@ CHECK_RETCODE
 CHECK_RETCODE
 ./run_driver --dlreopen --push
 CHECK_RETCODE
+./run_driver --thrdopen --push
+CHECK_RETCODE
 ./run_driver --reorder --push
 CHECK_RETCODE
 ./run_driver --partial --push
@@ -26,6 +28,8 @@ CHECK_RETCODE
 ./run_driver --dlopen --pull
 CHECK_RETCODE
 ./run_driver --dlreopen --pull
+CHECK_RETCODE
+./run_driver --thrdopen --pull
 CHECK_RETCODE
 ./run_driver --reorder --pull
 CHECK_RETCODE
@@ -42,6 +46,8 @@ CHECK_RETCODE
 CHECK_RETCODE
 ./run_driver --dlreopen --numa
 CHECK_RETCODE
+./run_driver --thrdopen --numa
+CHECK_RETCODE
 ./run_driver --reorder --numa
 CHECK_RETCODE
 ./run_driver --partial --numa
@@ -57,6 +63,8 @@ CHECK_RETCODE
 ./run_driver --dlopen --fork
 CHECK_RETCODE
 ./run_driver --dlreopen --fork
+CHECK_RETCODE
+./run_driver --thrdopen --fork
 CHECK_RETCODE
 ./run_driver --reorder --fork
 CHECK_RETCODE
@@ -75,6 +83,8 @@ CHECK_RETCODE
 CHECK_RETCODE
 ./run_driver --dlreopen --forkexec
 CHECK_RETCODE
+./run_driver --thrdopen --forkexec
+CHECK_RETCODE
 ./run_driver --reorder --forkexec
 CHECK_RETCODE
 ./run_driver --partial --forkexec
@@ -91,6 +101,8 @@ CHECK_RETCODE
 CHECK_RETCODE
 ./run_driver --dlreopen --chdir
 CHECK_RETCODE
+./run_driver --thrdopen --chdir
+CHECK_RETCODE
 ./run_driver --reorder --chdir
 CHECK_RETCODE
 ./run_driver --partial --chdir
@@ -105,6 +117,8 @@ CHECK_RETCODE
 ./run_driver --dlopen --preload
 CHECK_RETCODE
 ./run_driver --dlreopen --preload
+CHECK_RETCODE
+./run_driver --thrdopen --preload
 CHECK_RETCODE
 ./run_driver --reorder --preload
 CHECK_RETCODE
@@ -123,6 +137,8 @@ CHECK_RETCODE
 CHECK_RETCODE
 ./run_driver --dlreopen --session
 CHECK_RETCODE
+./run_driver --thrdopen --session
+CHECK_RETCODE
 ./run_driver --reorder --session
 CHECK_RETCODE
 ./run_driver --partial --session
@@ -138,6 +154,7 @@ else
 echo Skipping: ./run_driver --dependency --session
 echo Skipping: ./run_driver --dlopen --session
 echo Skipping: ./run_driver --dlreopen --session
+echo Skipping: ./run_driver --thrdopen --session
 echo Skipping: ./run_driver --reorder --session
 echo Skipping: ./run_driver --partial --session
 echo Skipping: ./run_driver --ldpreload --session

--- a/testsuite/test_driver.c
+++ b/testsuite/test_driver.c
@@ -37,6 +37,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <dirent.h>
+#include <pthread.h>
 
 #include "spindle.h"
 #include "ccwarns.h"
@@ -80,6 +81,7 @@ typedef enum
    om_ldpreload,
    om_dependency,
    om_dlopen,
+   om_thrdopen,
    om_dlreopen,
    om_reorder,
    om_partial,
@@ -538,6 +540,25 @@ void dlopen_mode()
    }
 }
 
+static void* thrd_dlopen_mode(void *arg)
+{
+   dlopen_mode();
+   return NULL;
+}
+
+void thrd_mode()
+{
+   pthread_t thrd;
+   int result;
+
+   result = pthread_create(&thrd, NULL, thrd_dlopen_mode, NULL);
+   if (result != 0) {
+      err_printf("pthread_create returned error code %d\n", result);
+      return;
+   }
+   pthread_join(thrd, NULL);
+}
+
 void dlreopen_mode()
 {
    dependency_mode();
@@ -696,6 +717,9 @@ void open_libraries()
          break;
       case om_dlopen:
          dlopen_mode();
+         break;
+      case om_thrdopen:
+         thrd_mode();
          break;
       case om_dlreopen:
          dlreopen_mode();
@@ -1022,6 +1046,7 @@ void parse_args(int argc, char *argv[])
       TEST_ARG(ldpreload);
       TEST_ARG(dependency);
       TEST_ARG(dlopen);
+      TEST_ARG(thrdopen);
       TEST_ARG(dlreopen);
       TEST_ARG(reorder);
       TEST_ARG(partial);
@@ -1088,6 +1113,8 @@ void checkTlsSum()
    int sum = 0;
 
    if (open_mode == om_spindleapi)
+      return;
+   if (open_mode == om_thrdopen)
       return;
 
    for (i = 0; libraries[i].libname; i++) {


### PR DESCRIPTION
A user reported spindle crashes, which came from the get_nprocs routine called under spindle malloc usage. 
Upon investigation this was https://sourceware.org/bugzilla/show_bug.cgi?id=32483. The application created a thread that reached spindle and called get_nprocs(). That routine called 'isspace' routine, which access locale, and triggered the bug described above and crashed.

This PR checks for new threads using a safe version of TLS, then manually resets the locale for any new threads. That works around the latter sigsegv that would come under spindle malloc usage.

This PR also adds a set of heap debugging routines (which are currently off) that were used while diagnosing this.

We also added a test. The test doesn't reproduce the original fault and could use more work, but is still a useful test.