### PR TITLE
Pin Flux version for CI to v0.48.0

### DIFF
--- a/containers/spindle-flux-ubuntu/docker-compose.yml
+++ b/containers/spindle-flux-ubuntu/docker-compose.yml
@@ -7,9 +7,10 @@ x-shared-workers:
   &workers
   replicas: 4 
 
-# Ubuntu version to use (noble = 24.04)
+# Base flux image version to use
+# ${ubuntu_version}-${flux_version}-${arch}
 x-shared-build-args: &shared-build-args
-  flux_sched_version: noble
+  flux_sched_version: noble-v0.48.0-amd64
   <<: *workers
 
 # Docker prohibits copying files from outside of the build context.


### PR DESCRIPTION
The CI testing container for Flux was specifying the image tag `noble`, which is the most recent version using Ubuntu noble (24.04). That tag was recently updated with a new development version of Flux which changes something such that it no longer accepts the broker.toml config file we use, causing the cluster to fail to start. 

This fixes the problem by pinning Flux to the current most recent release, v0.48.0. This restores the Flux CI to functionality. 