### PR TITLE
Have la_version return provide audit version rather than hardcoded 1

### DIFF
--- a/src/client/auditclient/auditclient.c
+++ b/src/client/auditclient/auditclient.c
@@ -29,9 +29,8 @@ extern void restore_pathpatch();
 
 unsigned int spindle_la_version(unsigned int version)
 {
-   (void)version;
    patchDTV_init();
-   return 1;
+   return version;
 }
 
 void spindle_la_activity (uintptr_t *cookie, unsigned int flag)

--- a/src/client/auditclient/auditclient_common.c
+++ b/src/client/auditclient/auditclient_common.c
@@ -48,7 +48,11 @@ unsigned int la_version(unsigned int version)
    debug_printf("la_version function is loaded at %p\n", la_version);
    debug_printf3("la_version(): %d\n", version);
    init_bindings_hash();
-   return spindle_la_version(version);
+   
+   result = spindle_la_version(version);
+   if (result == -1)
+      return 0;
+   return result;
 }
 
 char *la_objsearch(const char *name, uintptr_t *cookie, unsigned int flag)

--- a/src/client/subaudit/subaudit.c
+++ b/src/client/subaudit/subaudit.c
@@ -27,7 +27,6 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 unsigned int spindle_la_version(unsigned int version)
 {
-   (void)version;
    int result;
    int binding_offset = 0;
 
@@ -39,7 +38,7 @@ unsigned int spindle_la_version(unsigned int version)
    debug_printf3("Updating subaudit bindings with offset %d\n", binding_offset);
    init_plt_binding_func(binding_offset);
 
-   return 1;
+   return version;
 }
 
 static void bind_to_libc()


### PR DESCRIPTION
Fixes #143 

Change the compatibility version returned to AUDIT via la_version() to reflect whichever version is actually running. 

@SamHerts -- I don't have an aarch64 system to test this against. Can you let us know if this works?

