### PR TITLE
Sessions support for SPANK plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,11 @@ jobs:
         run: |
           docker exec slurm-plugin-head bash -c 'cd Spindle-build/testsuite && salloc -n${workers} -N${workers} ./runTests ${workers}'
 
+      - name: Run spindle-slurm-plugin-ubuntu session testsuite
+        id: slurm-ubuntu-testsuite-sessions
+        run: |
+          docker exec slurm-plugin-head bash -c 'cd Spindle-build/testsuite && salloc -n${workers} -N${workers} --spindle-session ./runTests ${workers}'
+
       - name: Bring spindle-slurm-plugin-ubuntu down
         id: slurm-ubuntu-down
         if: ${{ always() }}

--- a/src/slurm_plugin/plugin_utils.c
+++ b/src/slurm_plugin/plugin_utils.c
@@ -7,8 +7,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/wait.h>
+#include <sys/un.h>
+#include <sys/socket.h>
 #include <fcntl.h>
-#include <sys/types.h>
 #include <pwd.h>
 #include "plugin_utils.h"
 
@@ -32,6 +33,46 @@
 extern char *parse_location(char *loc, number_t number);
 extern char *realize(char *path);
 extern int spindle_mkdir(char *orig_path);
+
+int srunAllNodes(unsigned int num_nodes, const char *command) 
+{
+   pid_t pid;
+   int result, status, error;
+
+   pid = fork();
+   if (pid == -1) {
+      error = errno;
+      sdprintf(1, "ERROR: Failed for fork for srun: %s\n", strerror(error));
+      return -1;
+   } else if (pid == 0) {
+      // In child
+      char n[12];
+      snprintf(n, sizeof(n), "%u", num_nodes);
+      execlp("srun",
+             "srun", 
+             "--nodes", n,
+             "--ntasks", n,
+             "--external-launcher",
+             "--spindle",
+             command,
+             (char*)NULL);
+      error = errno;
+      sdprintf(1, "ERROR: Failed to exec srun: %s\n", strerror(error));
+      exit(-1);
+   } else {
+      // In parent
+      result = waitpid(pid, &status, 0);
+      if (result == -1) {
+         error = errno;
+         sdprintf(1, "ERROR: Failed to wait for srun: %s\n", strerror(error));
+         return -1;
+      } else if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+         sdprintf(1, "ERROR: Failure in srun");
+         return -1;
+      }
+   }
+   return 0;
+}
 
 char **getHostsScontrol(unsigned int num_hosts, const char *hoststr)
 {
@@ -257,18 +298,12 @@ int isFEHost(char **hostlist, unsigned int num_hosts)
    return feresult;      
 }
 
-char *unique_file = NULL;
-
-#define UNIQUE_FILE_NAME "spindle_unique"
-
-int isBEProc(spindle_args_t *params, unsigned int exit_phase)
+static char* locSpecificDir(spindle_args_t *params) 
 {
-   char *dir = NULL, *expanded_dir = NULL, *realized_dir = NULL, *phase_name = NULL;
+   char *dir = NULL, *expanded_dir = NULL, *realized_dir = NULL;
    char hostname[256], session_id_str[32];
    size_t unique_file_len;
-   int beproc_result = -1;
-   int fd = -1, error;
-   
+
    dir = params->location;
    if (!dir) {
       sdprintf(1, "ERROR: Location not filled in\n");
@@ -283,6 +318,216 @@ int isBEProc(spindle_args_t *params, unsigned int exit_phase)
    if (!realized_dir) {
       sdprintf(1, "ERROR: Could not turn dir to a real path\n");
    }
+
+  done:
+   if (expanded_dir)
+      free(expanded_dir);
+
+   return realized_dir;
+}
+
+#define SOCKET_PREFIX "spFE"
+
+static char* exitSocketPath(spindle_args_t *params)
+{
+   char *realized_dir, *socket_path = NULL;
+   char session_id_str[32];
+   size_t socket_path_len;
+
+   realized_dir = locSpecificDir(params);
+   if (!realized_dir) {
+      err_printf("Could not get real path for FE exit socket\n");
+      goto done;
+   }
+
+   snprintf(session_id_str, sizeof(session_id_str), "%lu", (unsigned long) params->number);
+
+   socket_path_len = strlen(realized_dir) + 1 + 
+                     strlen(SOCKET_PREFIX) + 1 + 
+                     strlen(session_id_str) + 1;
+
+   socket_path = (char *) malloc(sizeof(char) * socket_path_len);
+   snprintf(socket_path, socket_path_len, "%s/%s.%s", realized_dir, SOCKET_PREFIX, session_id_str);
+
+  done:
+   if (realized_dir)
+      free(realized_dir);
+
+   return socket_path;
+}
+
+static int createFEExitSocket(char *socket_path) 
+{
+   struct sockaddr_un local;
+   int result, sock = -1, retval = -1;
+
+   debug_printf("Creating unix socket for session at %s\n", socket_path);
+   sock = socket(AF_UNIX, SOCK_STREAM, 0);
+   if (sock == -1) {
+      int error = errno;
+      err_printf("Could not create socket for spindle session: %s\n", strerror(error));
+      goto done;
+   }
+
+   local.sun_family = AF_UNIX;
+   strncpy(local.sun_path, socket_path, sizeof(local.sun_path)-1);
+   result = bind(sock, (struct sockaddr *) &local, sizeof(local));
+   if (result == -1) {
+      int error = errno;
+      err_printf("Could not bind socket %s for spindle session: %s\n", local.sun_path, strerror(error));
+      goto done;
+   }
+
+   result = listen(sock, 1);
+   if (result == -1) {
+      int error = errno;
+      err_printf("Could not listen on server socket %s for spindle session: %s", local.sun_path, strerror(error));
+      goto done;
+   }
+   retval = sock;
+   
+  done:
+   if (sock != -1 && result == -1)
+      close(sock); 
+
+   return retval;
+}
+
+int doesFEExitSocketExist(spindle_args_t *params) 
+{
+   struct stat sb;
+   char * socket_path = NULL;
+   
+   socket_path = exitSocketPath(params);
+   if (!socket_path)
+      return 0;
+
+   if (stat(socket_path, &sb) == -1)
+      return 0;
+
+   return S_ISSOCK(sb.st_mode);
+}
+
+int waitForSpankSessionEnd(spindle_args_t *params) 
+{
+   int fd = -1, sockfd = -1, error, retval = -1, result;
+   char msg;
+   char *socket_path = NULL;
+
+   sdprintf(2, "In waitForSpankSessionEnd\n");
+
+   socket_path = exitSocketPath(params);
+   if (!socket_path) 
+      goto done;
+
+   sockfd = createFEExitSocket(socket_path);
+   if (sockfd == -1) 
+      goto done;
+   
+   fd = accept(sockfd, NULL, NULL);
+   if (fd == -1) {
+      error = errno;
+      err_printf("Could not accept session exit socket connection: %s\n", strerror(error));
+      goto done;
+   }
+
+   do {
+      result = read(fd, &msg, 1);
+   } while (result == -1 && errno == EINTR);
+   if (result == -1) {
+      error = errno;
+      err_printf("Failed to read from session exit socket: %s\n", strerror(error));
+      goto done;
+   }
+   if (msg != 'q') {
+      error = errno;
+      err_printf("Recieved incorrect msg character: %c\n", msg);
+      goto done;
+   }
+   
+   sdprintf(2, "Received session exit message\n");   
+   retval = 0;
+
+  done:
+   if (fd != -1)
+      close(fd);
+   if (sockfd != -1)
+      close(sockfd);
+   if (socket_path) {
+      unlink(socket_path);
+      free(socket_path);
+   }
+   return retval;
+}
+
+int signalSpankSessionEnd(spindle_args_t *params) 
+{
+   int sockfd = -1, error, retval = -1, result;
+   char msg;
+   struct sockaddr_un saddr;
+   char *socket_path = NULL;
+
+   sdprintf(2, "In signalSpankSessionEnd\n");
+
+   socket_path = exitSocketPath(params);
+   if (!socket_path) 
+      goto done;
+
+   sockfd = socket(AF_UNIX, SOCK_STREAM, 0);
+   if (sockfd == -1) {
+      error = errno;
+      err_printf("Could not create session exit socket: %s\n", strerror(error));
+      goto done;
+   }
+
+   saddr.sun_family = AF_UNIX;
+   strncpy(saddr.sun_path, socket_path, sizeof(saddr.sun_path)-1);
+
+   result = connect(sockfd, (const struct sockaddr *) &saddr, sizeof(saddr));
+   if (result == -1) {
+      int error = errno;
+      err_printf("Failed to connect to session exit socket: %s\n", strerror(error));
+      return -1;
+   }
+
+   msg = 'q';
+   do {
+      result = write(sockfd, &msg, 1);
+   } while (result == -1 && errno == EINTR);
+   if (result == -1) {
+      error = errno;
+      err_printf("Failed to write value to session exit socket: %s\n", strerror(error));
+      goto done;
+   }
+   if (result == 0) {
+      err_printf("Socket closed before we could write to session exit socket\n");
+      goto done;
+   }
+
+   retval = 0;
+   
+  done:
+   if (sockfd != -1)
+      close(sockfd);
+   if (socket_path) 
+      free(socket_path);
+
+   return retval;
+}
+
+char *unique_file = NULL;
+
+#define UNIQUE_FILE_NAME "spindle_unique"
+
+int isBEProc(spindle_args_t *params, unsigned int exit_phase)
+{
+   char *realized_dir = NULL, *phase_name = NULL;
+   char hostname[256], session_id_str[32];
+   size_t unique_file_len;
+   int beproc_result = -1;
+   int fd = -1, error;
+   
+   realized_dir = locSpecificDir(params);
 
    gethostname(hostname, sizeof(hostname));
    hostname[sizeof(hostname)-1] = '\0';
@@ -317,8 +562,6 @@ int isBEProc(spindle_args_t *params, unsigned int exit_phase)
    }
    
   done:
-   if (expanded_dir)
-      free(expanded_dir);
    if (realized_dir)
       free(realized_dir);
    if (fd != -1)
@@ -1021,6 +1264,14 @@ char *readSpankEnv(spank_t spank, const char *envname)
    char *buffer;
    int buffer_size = 4096;
    spank_err_t err;
+   spank_context_t ctx;
+
+   /* spank_getenv crashes if called from S_CTX_JOB_SCRIPT */
+   ctx = spank_context();
+   if (ctx == S_CTX_JOB_SCRIPT) {
+      buffer = getenv(envname);
+      return buffer ? strdup(buffer) : NULL;
+   }
 
    buffer = (char *) malloc(buffer_size);
    for (;;) {

--- a/src/slurm_plugin/plugin_utils.h
+++ b/src/slurm_plugin/plugin_utils.h
@@ -38,6 +38,7 @@ int decodeSpindleConfig(const char *encodedstr,
                         unsigned int *port, unsigned int *num_ports, uint64_t *unique_id, uint32_t *security_type,
                         int *spindle_argc, char ***spindle_argv);
 
+int srunAllNodes(unsigned int num_nodes, const char *command);
 char **getHostsScontrol(unsigned int num_hosts, const char *hoststr);
 char **getHostAddrSinfo(unsigned int num_hosts, char **hostlist);
 char **getHostsParse(unsigned int num_hosts, const char *shortlist);
@@ -45,6 +46,10 @@ char **getHostsParse(unsigned int num_hosts, const char *shortlist);
 int isFEHost(char **hostlist, unsigned int num_hosts);
 extern char *unique_file;
 int isBEProc(spindle_args_t *params, unsigned int exit_phase);
+
+int doesFEExitSocketExist(spindle_args_t *params);
+int waitForSpankSessionEnd(spindle_args_t *params);
+int signalSpankSessionEnd(spindle_args_t *params);
 
 char *encodeCmdArgs(int sargc, char **sargv);
 void decodeCmdArgs(char *cmd, int *sargc, char ***sargv);

--- a/src/slurm_plugin/slurm_plugin.c
+++ b/src/slurm_plugin/slurm_plugin.c
@@ -1,4 +1,5 @@
 /*
+
 This file is part of Spindle.  For copyright information see the COPYRIGHT 
 file in the top level directory, or at 
 https://github.com/hpc/Spindle/blob/master/COPYRIGHT
@@ -17,6 +18,8 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <sys/stat.h>
+#include <sys/un.h>
+#include <sys/socket.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <string.h>
@@ -31,16 +34,32 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 
 #include "config.h"
 
+#define SPINDLE_USE_SESSION "SPINDLE_USE_SESSION"
+#define SPANK_SPINDLE_USE_SESSION "SPANK_" SPINDLE_USE_SESSION
+
 SPINDLE_EXPORT extern const char plugin_name[];
 SPINDLE_EXPORT extern const char plugin_type[];
 SPINDLE_EXPORT extern const unsigned int plugin_version;
 SPINDLE_EXPORT extern struct spank_option spank_options[];
 SPINDLE_EXPORT int slurm_spank_task_init(spank_t spank, int ac, char *argv[]);
 SPINDLE_EXPORT int slurm_spank_task_exit(spank_t spank, int ac, char *argv[]);
+SPINDLE_EXPORT int slurm_spank_init(spank_t spank, int ac, char *argv[]);
+SPINDLE_EXPORT int slurm_spank_init_post_opt(spank_t spank, int ac, char *argv[]);
+SPINDLE_EXPORT int slurm_spank_local_user_init(spank_t spank, int ac, char *argv[]);
 SPINDLE_EXPORT int slurm_spank_exit(spank_t spank, int site_argc, char *site_argv[]);
+SPINDLE_EXPORT int slurm_spank_job_prolog(spank_t spank, int ac, char *argv[]);
+SPINDLE_EXPORT int slurm_spank_job_epilog(spank_t spank, int ac, char *argv[]);
 
+/* Fail the job, not the node, if the plugin fails. */
+SPINDLE_EXPORT int slurm_spank_init_failure_mode = ESPANK_JOB_FAILURE;
 
 SPANK_PLUGIN(spindle, 1)
+
+typedef struct {
+   spank_t spank;
+   int site_argc;
+   char **site_argv;
+} start_params_t;
 
 typedef struct {
    spank_t spank;
@@ -53,25 +72,40 @@ static int set_spindle_args(spank_t spank, spindle_args_t *params, int argc, cha
 static int get_spindle_args(spank_t spank, spindle_args_t *params);
 #endif
 
+static int should_use_session(spank_t spank);
+static int forward_environment_to_job_control(spank_t spank);
 static int forward_environment_to_slurmstepd(spank_t spank);
+static int handle_forwarded_environment(void);
 static int launchFE(char **hostlist, spindle_args_t *params);
 static int launchBE(spank_t spank, spindle_args_t *params);
 static int prepApp(spank_t spank, spindle_args_t *params);
 static int launch_spindle(spank_t spank, spindle_args_t *params);
-static unique_id_t getUniqueID(spank_t spank);
+static unique_id_t getUniqueID(spank_t spank, int session_enabled);
 static int spindle_options(int val, const char *optarg, int remote);
-static int process_spindle_args(spank_t spank, int site_argc, char *site_argv[], spindle_args_t *params, int *out_argc, char ***out_argv);
+static int spindle_session_options(int val, const char *optarg, int remote);
+static int fillInArgs(spank_t spank, spindle_args_t *args, int argc, char **argv, unique_id_t unique_id, int session_enabled);
+static int process_spindle_args(spank_t spank, int site_argc, char *site_argv[], spindle_args_t *params, int *out_argc, char ***out_argv, int session_enabled);
 static int handleExit(void *params, char **output_str);
+static int handleStart(void *params, char **output_str);
+static int get_num_hosts(spank_t spank);
+static int get_num_hosts_job(spank_t spank);
+static int get_num_hosts_step(spank_t spank);
+static spank_err_t get_stepid(spank_t spank, uint32_t *stepid);
+static spank_err_t get_jobid(spank_t spank, uint32_t * jobid);
+static char **get_hostlist(spank_t spank, unsigned int num_hosts);
+static char **get_hostlist_job(spank_t spank, unsigned int num_hosts);
+static char **get_hostlist_step(spank_t spank, unsigned int num_hosts);
    
 static pid_t pidBE = 0;
 static pid_t pidFE = 0;
 static __thread spank_t current_spank;
 static const char *user_options = NULL;
 static int enable_spindle = 0;
+static int start_session = 0;
 
-extern char **environ;
 extern char *parse_location(char *loc, number_t number);
 
+// CLI options for srun
 struct spank_option spank_options[] =
 {
    { "spindle", "[spindle options]",
@@ -81,32 +115,344 @@ struct spank_option spank_options[] =
    SPANK_OPTIONS_TABLE_END
 };
 
-static int forward_environment_to_slurmstepd(spank_t spank) 
+// CLI options for salloc and sbatch
+struct spank_option session_option =
 {
-   char *debugEnv, *testEnv, *tmpEnv;
+   "spindle-session", NULL, 
+   "Start a Spindle session for this allocation", 0, 0,
+   (spank_opt_cb_f) spindle_session_options
+};
 
-   debugEnv= readSpankEnv(spank, "SPINDLE_DEBUG");
-   testEnv = readSpankEnv(spank, "SPINDLE_TEST");
-   tmpEnv = readSpankEnv(spank, "TMPDIR");
+static int should_use_session(spank_t spank) {
+   spank_context_t context;
+   spank_err_t err;
+   char * session_env;
 
-   if (debugEnv) {
-      setenv("SPINDLE_DEBUG", debugEnv, 1);
-      free(debugEnv);
+   context = spank_context();
+
+   /* The technique for checking the session flag is different in
+      different contexts. In local, we're running where the args
+      were processed so we can check the flag directly . */
+   if (context == S_CTX_LOCAL) {
+      session_env = getenv(SPANK_SPINDLE_USE_SESSION);
+      return (start_session || session_env);
    }
-
-   if (testEnv) {
-      setenv("SPINDLE_TEST", testEnv, 1);
-      free(testEnv);
+   /* In remote, we're running in a different process, so we check
+      the env var set earlier in the local context. */
+   if (context == S_CTX_REMOTE) {
+      session_env = readSpankEnv(spank, SPANK_SPINDLE_USE_SESSION);
+      if(session_env) {
+         free(session_env);
+         return 1;
+      }
    }
-
-   if (tmpEnv) {
-      setenv("TMPDIR", tmpEnv, 1);
-      free(tmpEnv);
+   /* In the job script, due to a bug in SPANK, env vars are propagated
+      to the prolog but not the epilog, so in the epilog instead we use
+      spank_option_getopt (but this doesn't work in remote context
+      which is why we need cases for both remote and job script). */
+   if (context == S_CTX_JOB_SCRIPT) {
+      session_env = getenv(SPANK_SPINDLE_USE_SESSION);
+      if (session_env) 
+         return 1;
+      err = spank_option_getopt(spank, &session_option, NULL);
+      return (err == ESPANK_SUCCESS); 
    }
 
    return 0;
 }
 
+int slurm_spank_init(spank_t spank, int ac, char *argv[]) {
+   spank_context_t context;
+   context = spank_context();
+   if (context == S_CTX_ALLOCATOR) {
+      spank_option_register(spank, &session_option);
+   }
+   return 0;
+}
+
+int slurm_spank_init_post_opt(spank_t spank, int ac, char *argv[]) { 
+   spank_context_t context;
+   unique_id_t session_unique_id;
+        
+
+   context = spank_context();
+   /* In sbatch and salloc, forward session status in env var to make it
+      available in in other contexts. */
+   if (context == S_CTX_ALLOCATOR) {
+      if (enable_spindle) {
+         setenv("SPANK_SPINDLE", "1", 1);
+      }
+      if (start_session) {
+         setenv(SPANK_SPINDLE_USE_SESSION, "1", 1);
+      }
+   }
+   return 0;
+}
+
+/* Environment Forwarding
+ * 
+ * There are three different sets of env vars:
+ *    - Standard env vars (getenv/setenv) in local and allocator context
+ *    - Job env vars (spank_getenv/spank_setenv) in remote context
+ *    - Job control env vars (spank_job_control_getenv/spank_job_control_setenv) in job control context
+ * Spindle itself will get env vars using getenv/setenv, so in remote and job control
+ * contexts, we have to read from the Slurm-specific context and setenv.
+ */ 
+static int forward_environment_to_job_control(spank_t spank) 
+{
+   spank_err_t err;
+   char *envVal;
+
+   if (should_use_session(spank)) {
+      /* Forward session status from srun to job prolog. */
+      err = spank_job_control_setenv(spank, SPINDLE_USE_SESSION, "1", 1);
+      if (err != ESPANK_SUCCESS) return -1;
+   }
+
+   envVal = getenv("SPINDLE_DEBUG");
+   if (envVal) {
+       err = spank_job_control_setenv(spank, "SPINDLE_DEBUG", envVal, 1);
+       if (err != ESPANK_SUCCESS) return -1;
+   }
+
+   envVal = getenv("SPINDLE_TEST");
+   if (envVal) {
+       err = spank_job_control_setenv(spank, "SPINDLE_TEST", envVal, 1);
+       if (err != ESPANK_SUCCESS) return -1;
+   }
+   envVal = getenv("TMPDIR");
+   if (envVal) {
+       err = spank_job_control_setenv(spank, "TMPDIR", envVal, 1);
+       if (err != ESPANK_SUCCESS) return -1;
+   } else {
+       err = spank_job_control_setenv(spank, "TMPDIR", "/tmp", 1);
+       if (err != ESPANK_SUCCESS) return -1;
+   }
+
+   /* In the job control context, the SLURM_JOB_NODELIST incorrectly
+    * contains the nodes of the STEP rather than the job, so we save
+    * a copy from local context, where we have the correct value. */
+   envVal = getenv("SLURM_JOB_NODELIST");
+   if (envVal) {
+      err = spank_job_control_setenv(spank, "SPINDLE_JOB_NODELIST", envVal, 1);
+      if (err != ESPANK_SUCCESS) return -1;
+   }
+
+   return 0;
+}    
+
+/* SPINDLE_DEBUG, SPINDLE_TEST, and TMPDIR are used in initializing
+ * debug logging. Thus, these env vars need to be forwarded early,
+ * before any debug logging can occur. */
+static int forward_environment_to_slurmstepd(spank_t spank) 
+{
+   char *envVal;
+
+   envVal = readSpankEnv(spank, "SPINDLE_DEBUG");
+   if (envVal) {
+      setenv("SPINDLE_DEBUG", envVal, 1);
+      free(envVal);
+   }
+
+   envVal = readSpankEnv(spank, "SPINDLE_TEST");
+   if (envVal) {
+      setenv("SPINDLE_TEST", envVal, 1);
+      free(envVal);
+   }
+
+   envVal = readSpankEnv(spank, "TMPDIR");
+   if (envVal) {
+      setenv("TMPDIR", envVal, 1);
+      free(envVal);
+   }
+
+   return 0;
+}
+
+/* spank_job_control_setenv always prepends "SPANK_"
+ * to the env var name. Read the "SPANK_"-prefixed version
+ * and set the one Spindle expects. */
+static int handle_forwarded_environment(void) 
+{
+   char * envVal;
+   envVal = getenv("SPANK_SPINDLE_DEBUG");
+   if (envVal) {
+      setenv("SPINDLE_DEBUG", envVal, 1);
+   }
+   envVal = getenv("SPANK_SPINDLE_TEST");
+   if (envVal) {
+      setenv("SPINDLE_TEST", envVal, 1);
+   }
+   envVal = getenv("SPANK_TMPDIR");
+   if (envVal) {
+      setenv("TMPDIR", envVal, 1);
+   }
+   envVal = getenv("SPANK_SPINDLE_JOB_NODELIST");
+   if (envVal) {
+      setenv("SPINDLE_JOB_NODELIST", envVal, 1);
+   }
+   return 0;
+}
+
+/* local_user_init callback happens in srun after the step
+ * is ready to run but before it starts running. */
+int slurm_spank_local_user_init(spank_t spank, int ac, char *argv[]) 
+{
+   int result, use_session, num_hosts;
+   char * envVal;
+   uint32_t stepid;
+   spank_err_t err;
+   spindle_args_t params = {0};
+   
+   /* It is only valid to call spank_job_control_setenv from local
+    * context, so we have to use this callback to forward env vars
+    * to job control. */
+   result = forward_environment_to_job_control(spank);
+   if (result == -1) {
+      slurm_error("ERROR: Spindle plugin error. Unable to forward environment variables to job control.\n");
+      goto done;
+   }
+
+   use_session = should_use_session(spank); 
+   if (!use_session)
+      goto done;
+
+   result = process_spindle_args(spank, ac, argv, &params, NULL, NULL, use_session);
+   if (result == -1) {
+      slurm_error("ERROR: Spindle plugin error. Could not process spindle args in local user init.\n");
+      return -1;
+   }
+   
+   /* For sessions without rshlaunch, session start happens in the prolog.
+    * For sessions with rshlaunch, session start happens in task_init.
+    * For rshlaunch, set SPINDLE_RSHLAUNCH in job control to signal prolog not to start session. */
+   if (params.opts & OPT_RSHLAUNCH) {
+      err = spank_job_control_setenv(spank, "SPINDLE_RSHLAUNCH", "1", 1);
+      if (err != ESPANK_SUCCESS) {
+         slurm_error("ERROR: Spindle plugin error. Could not set job control env var.");
+         return -1;
+      }
+      goto done;
+   }
+   
+   /* For non-rshlaunch sessions, we have to force the prolog to run on every node.
+    * To do that, we do a dummy srun in the first step (step 0) on all nodes. */
+   err = get_stepid(spank, &stepid);
+   if (err != ESPANK_SUCCESS) {
+     slurm_error("ERROR: Spindle plugin error. Could not get step id.");
+     return -1;
+   }
+
+   if (stepid != 0)
+      goto done;
+
+   /* Guard against starting session more than once. */
+   envVal = getenv("SPANK_SPINDLE_SESSION_INIT");
+   if (envVal && strcmp(envVal, "1") == 0) 
+      goto done;
+   setenv("SPANK_SPINDLE_SESSION_INIT", "1", 1);
+
+   num_hosts = get_num_hosts_job(spank);
+   if (num_hosts == -1) {
+      slurm_error("ERROR: Spindle plugin error. Unable to get number of hosts\n");
+      result = -1;
+      goto done;
+   }
+
+   /* Force prolog to run on all nodes. */
+   result = srunAllNodes((unsigned int)num_hosts, "/bin/true");
+
+  done:
+   return result;
+}
+
+
+/* job_prolog callback called on the compute node just before job
+ * start the first time a step runs on any given node within a job. */
+int slurm_spank_job_prolog(spank_t spank, int ac, char *argv[]) {
+   uid_t userid;
+   start_params_t start_params;
+   spank_err_t err;
+   int result, use_session;
+   char *result_str, *work_dir, *envVal;
+   
+   handle_forwarded_environment();
+   use_session = should_use_session(spank);
+
+   if (!use_session) 
+      return 0;
+   
+   
+   envVal = getenv("SPANK_SPINDLE_RSHLAUNCH");
+   if (envVal && strcmp(envVal, "1") == 0) 
+      return 0;
+
+   // The prolog starts in the user's home directory.
+   // Change to $SLURM_JOB_WORK_DIR so logs go to right place.
+   work_dir = getenv("SLURM_JOB_WORK_DIR");
+   if (work_dir) {
+      chdir(work_dir);
+   }
+
+   err = spank_get_item(spank, S_JOB_UID, &userid);
+   if (err != ESPANK_SUCCESS) {
+      slurm_error("ERROR: Spindle plugin error.  Could not get uid in exit\n");
+      return -1;
+   }
+
+   start_params.spank = spank;
+   start_params.site_argc = ac;
+   start_params.site_argv = argv;
+
+   result = dropPrivilegeAndRun(handleStart, userid, &start_params, &result_str);
+
+   if (result == -1) {
+      slurm_error("Failed to start Spindle for session\n");
+      return -1;
+   }
+
+   return 0;
+}
+
+/* job_epilog called on every compute node when allocation ends, 
+ * regardless of whether any step ever ran on that node and
+ * even if the prolog never ran. */
+int slurm_spank_job_epilog(spank_t spank, int ac, char *argv[]) {
+   int result, use_session;
+   char *result_str;
+   spank_err_t err;
+   uid_t userid;
+   exit_params_t exit_params;
+
+   use_session = should_use_session(spank);
+
+   if (!use_session)
+      return 0;
+
+   // If session, shutdown BE and FE here.
+   
+   err = spank_get_item(spank, S_JOB_UID, &userid);
+   if (err != ESPANK_SUCCESS) {
+      slurm_error("ERROR: Spindle plugin error.  Could not get uid in epilog exit\n");
+      return -1;
+   }
+
+   exit_params.spank = spank;
+   exit_params.site_argc = ac;
+   exit_params.site_argv = argv;
+
+   result = dropPrivilegeAndRun(handleExit, userid, &exit_params, &result_str);
+   
+   if (result == -1) {
+      slurm_error("Failed to run handleExit.  Spindle may not shutdown properly\n");
+      return -1;
+   }
+   
+   return 0;
+}
+
+/* task_init callback called on the compute nodes for every task
+ * just before the application is exec'ed */
 int slurm_spank_task_init(spank_t spank, int site_argc, char *site_argv[])
 {
    spank_context_t context;
@@ -114,6 +460,12 @@ int slurm_spank_task_init(spank_t spank, int site_argc, char *site_argv[])
    saved_env_t *env = NULL;
    static int initialized = 0;
    spindle_args_t params = {0};
+   int use_session;
+   uid_t userid;
+   start_params_t start_params;
+   saved_env_t *saved_env;
+   char *result_str;
+   spank_err_t err;
 
    if (!enable_spindle)
       return 0;
@@ -123,6 +475,7 @@ int slurm_spank_task_init(spank_t spank, int site_argc, char *site_argv[])
    }   
 
    context = spank_context();
+
    if (context == S_CTX_ERROR) {
       slurm_error("ERROR: spank_context returned an error in spindle task_init plugin.\n");
       return -1;
@@ -133,16 +486,18 @@ int slurm_spank_task_init(spank_t spank, int site_argc, char *site_argv[])
    if (initialized) {
       return 0;
    }
-   
+
    // We need to acquire the job environment before we do anything that
    // will spawn the log daemon so that SPINDLE_DEBUG and SPINDLE_TEST
    // are set appropriately.
    forward_environment_to_slurmstepd(spank);
 
    sdprintf(1, "Beginning spindle plugin\n");
+   // Now do the rest of the environment forwarding after logging is initialized
    push_env(spank, &env);
-   
-   result = process_spindle_args(spank, site_argc, site_argv, &params, NULL, NULL);
+
+   use_session = should_use_session(spank);
+   result = process_spindle_args(spank, site_argc, site_argv, &params, NULL, NULL, use_session);
    if (result == -1) {
       sdprintf(1, "Error processesing spindle arguments.  Aborting spindle\n");
       goto done;
@@ -152,10 +507,13 @@ int slurm_spank_task_init(spank_t spank, int site_argc, char *site_argv[])
      return 0;
    }
 
-   result = launch_spindle(spank, &params);
-   if (result == -1) {
-      sdprintf(1, "Error launching spindle.  Aborting spindle\n");
-      goto done;
+   /* When using a session without RSHLAUNCH, handle start in job prolog, not here. */
+   if ((!use_session) || (params.opts & OPT_RSHLAUNCH)) {
+      start_params.spank = spank;
+      start_params.site_argc = site_argc;
+      start_params.site_argv = site_argv;
+
+      result = handleStart(&start_params, &result_str);
    }
 
    result = prepApp(spank, &params);
@@ -174,27 +532,82 @@ int slurm_spank_task_init(spank_t spank, int site_argc, char *site_argv[])
    return func_result;
 }
 
+static int handleStart(void *params, char **output_str) 
+{
+   start_params_t *start_params;
+   spank_t spank;
+   int site_argc, result, use_session;
+   uint32_t stepid;
+   char **site_argv;
+   spindle_args_t args = {0};
+   spank_err_t err;
+
+   start_params = (start_params_t *) params;
+   spank = start_params->spank;
+   site_argc = start_params->site_argc;
+   site_argv = start_params->site_argv;
+
+   sdprintf(1, "In handleStart\n");
+   use_session = should_use_session(spank);
+   result = process_spindle_args(spank, site_argc, site_argv, &args, NULL, NULL, use_session);
+   if (result == -1) {
+      sdprintf(1, "ERROR: Could not process spindle args in handlestart\n");
+      return -1;
+   }
+   
+   if (args.opts & OPT_OFF) {
+      return 0;
+   }
+
+   // Only initialize a session once
+   if (use_session && (args.opts & OPT_RSHLAUNCH)) {
+      err = get_stepid(spank, &stepid);
+      if (err != ESPANK_SUCCESS) {
+          slurm_error("ERROR: Spindle plugin error. Could not get step id.");
+          return -1;
+      }
+      if (stepid != 0) {
+          return 0;
+      }
+   }
+   
+   result = launch_spindle(spank, &args);
+   if (result == -1) {
+      sdprintf(1, "Error launching spindle.  Aborting spindle\n");
+      return -1;
+   }
+   return 0;
+}
+
+/* task_exit is called on compute node for each task just before exit */
 int slurm_spank_task_exit(spank_t spank, int site_argc, char *site_argv[])
 {
    spank_context_t context;
    char *result_str;
-   int result;
+   int result, use_session;
    uid_t userid;
    spank_err_t err;
    saved_env_t *saved_env;
    exit_params_t exit_params;
 
+   context = spank_context();
+
    if (!enable_spindle) {
       return 0;
    }
 
-   context = spank_context();
    if (context == S_CTX_ERROR) {
       slurm_error("ERROR: spank_context returned an error in spindle exit plugin.\n"); 
       return -1;
    }
    
    if (context != S_CTX_REMOTE) {
+      return 0;
+   }
+
+   use_session = should_use_session(spank);
+   if (use_session) {
+      /* When using a session, leave Spindle running between steps. */
       return 0;
    }
 
@@ -213,51 +626,81 @@ int slurm_spank_task_exit(spank_t spank, int site_argc, char *site_argv[])
    pop_env(saved_env);
    
    if (result == -1) {
-      slurm_error("Failed to run handleExit.  Spindle may not shutdown properly\n");
+      slurm_error("ERROR: Failed to run handleExit.  Spindle may not shutdown properly\n");
       return -1;
    }
    return 0;
 }
 
-static unique_id_t getUniqueID(spank_t spank)
+
+static spank_err_t get_stepid(spank_t spank, uint32_t *stepid)
 {
-   char *slurm_job_id_s, *slurm_step_id_s;
+   char *slurm_step_id_s;
+   spank_err_t err;
+   uint64_t combined;
+   
+   slurm_step_id_s = getenv("SLURM_STEP_ID");
+   if (slurm_step_id_s) {
+      *stepid = (uint32_t) atol(slurm_step_id_s);
+   } else {
+      err = spank_get_item(spank, S_JOB_STEPID, stepid);
+      if (err != ESPANK_SUCCESS) {
+         return err;
+      }
+   }
+
+   return ESPANK_SUCCESS;
+}
+
+static spank_err_t get_jobid(spank_t spank, uint32_t * jobid)
+{
+   char *slurm_job_id_s;
+   spank_err_t err;
+
+   slurm_job_id_s = getenv("SLURM_JOB_ID");
+   if (slurm_job_id_s) {
+      *jobid = (uint32_t) atol(slurm_job_id_s);
+   }
+   else {
+      err = spank_get_item(spank, S_JOB_ID, jobid);
+      if (err != ESPANK_SUCCESS) {
+         return err;
+      }
+   }
+
+   return ESPANK_SUCCESS;
+}
+
+static unique_id_t getUniqueID(spank_t spank, int session_enabled)
+{
    spank_err_t err;
    uint32_t jobid, stepid;
    uint64_t combined;
    
-   slurm_job_id_s = getenv("SLURM_JOB_ID");
-   if (slurm_job_id_s) {
-      jobid = (uint32_t) atol(slurm_job_id_s);
-   }
-   else {
-      err = spank_get_item(spank, S_JOB_ID, &jobid);
-      if (err != ESPANK_SUCCESS) {
-         slurm_error("Could not setup spindle:  Could not get SLURM_JOB_ID");
-         return 0;
-      }
+   err = get_jobid(spank, &jobid);
+   if (err != ESPANK_SUCCESS) {
+       slurm_error("ERROR: Could not setup spindle:  Could not get SLURM_JOB_ID\n");
+       return 0;
    }
 
-   slurm_step_id_s = getenv("SLURM_STEP_ID");
-   if (slurm_step_id_s) {
-      stepid = (uint32_t) atol(slurm_step_id_s);
-   }
-   else {
-      err = spank_get_item(spank, S_JOB_STEPID, &stepid);
+   if (!session_enabled) {
+      err = get_stepid(spank, &stepid);
       if (err != ESPANK_SUCCESS) {
-         slurm_error("Could not setup spindle: Could not get SLURM_STEP_ID");
+         slurm_error("ERROR: Could not setup spindle:  Could not get SLURM_STEP_ID\n");
          return 0;
       }
-   }
 
-   combined = stepid;
-   combined <<= 32;
-   combined |= jobid;
-   sdprintf(2, "Computed unique_id for session as %lu\n", (unsigned long) combined);
+      combined = stepid;
+      combined <<= 32;
+      combined |= jobid;
+   } else {
+      combined = jobid;
+   }
+   sdprintf(2, "Computed unique_id for session as %llu, session_enabled = %d\n", (unsigned long long) combined, session_enabled);
    return combined;
 }
 
-static int fillInArgs(spank_t spank, spindle_args_t *args, int argc, char **argv, unique_id_t unique_id)
+static int fillInArgs(spank_t spank, spindle_args_t *args, int argc, char **argv, unique_id_t unique_id, int session_enabled)
 {
    int result;
    char *oldlocation;
@@ -275,9 +718,17 @@ static int fillInArgs(spank_t spank, spindle_args_t *args, int argc, char **argv
       sdprintf(1, "Error processesing spindle options: %s\n", err_string ? err_string : "UNKNOWN");
       return -1;
    }
-   args->opts |= OPT_BEEXIT;
    args->use_launcher = slurm_plugin_launcher;
    args->startup_type = startup_external;
+
+   if (session_enabled) {
+      args->opts |= OPT_PERSIST;
+      args->opts |= OPT_SESSION;
+   } else if (args->opts & OPT_RSHLAUNCH) {
+      args->opts |= OPT_PERSIST;
+   } else {
+      args->opts |= OPT_BEEXIT;
+   }
 
    oldlocation = args->location;
    current_spank = spank;
@@ -287,7 +738,7 @@ static int fillInArgs(spank_t spank, spindle_args_t *args, int argc, char **argv
    return 0;
 }
 
-static int process_spindle_args(spank_t spank, int site_argc, char *site_argv[], spindle_args_t *params, int *out_argc, char ***out_argv)
+static int process_spindle_args(spank_t spank, int site_argc, char *site_argv[], spindle_args_t *params, int *out_argc, char ***out_argv, int session_enabled)
 {
    char *site_options = NULL, *combined_options = NULL;
    size_t combined_options_size, site_options_size, user_options_size;
@@ -296,7 +747,7 @@ static int process_spindle_args(spank_t spank, int site_argc, char *site_argv[],
    char *spindle_config = NULL;
    unique_id_t unique_id;
 
-   unique_id = getUniqueID(spank);
+   unique_id = getUniqueID(spank, session_enabled);
    if (!unique_id)
       return -1;
       
@@ -322,7 +773,7 @@ static int process_spindle_args(spank_t spank, int site_argc, char *site_argv[],
    sdprintf(1, "Combined site and user options are \"%s\"\n", combined_options);
 
    decodeCmdArgs(combined_options, &combined_argc, &combined_argv);
-   result = fillInArgs(spank, params, combined_argc, combined_argv, unique_id);
+   result = fillInArgs(spank, params, combined_argc, combined_argv, unique_id, session_enabled);
    if (result == -1)
       goto done;
 
@@ -352,16 +803,24 @@ static int process_spindle_args(spank_t spank, int site_argc, char *site_argv[],
    return post_opt_result;
 }
 
-static int get_num_hosts(spank_t spank)
+static int get_num_hosts_job(spank_t spank)
 {
    char *num_hosts_str;
    uint32_t num_hosts;
    int result;
    spank_err_t err;
-   
-   num_hosts_str = getenv("SLURM_NNODES");
+
+   num_hosts_str = readSpankEnv(spank, "SLURM_JOB_NUM_NODES");
    if (num_hosts_str) {
       result = atoi(num_hosts_str);
+      free(num_hosts_str);
+      if (result > 0)
+         return (int) result;
+   }
+   num_hosts_str = readSpankEnv(spank, "SLURM_NNODES");
+   if (num_hosts_str) {
+      result = atoi(num_hosts_str);
+      free(num_hosts_str);
       if (result > 0)
          return (int) result;
    }
@@ -369,20 +828,45 @@ static int get_num_hosts(spank_t spank)
    if (err != ESPANK_SUCCESS)
       return -1;
    return num_hosts;
-
 }
 
-static char **get_hostlist(spank_t spank, unsigned int num_hosts)
+static int get_num_hosts_step(spank_t spank)
 {
-   char *short_hosts, **hostlist;;
+   char *num_hosts_str;
+   int result;
+   
+   num_hosts_str = readSpankEnv(spank, "SLURM_STEP_NUM_NODES");
+   if (num_hosts_str) {
+      result = atoi(num_hosts_str);
+      if (result > 0)
+         return (int) result;
+   }
 
-   short_hosts = readSpankEnv(spank, "SLURM_STEP_NODELIST");
+   return -1;
+}
+
+static int get_num_hosts(spank_t spank)
+{
+   int result;
+   
+   result = get_num_hosts_step(spank);
+   if (result == -1)
+      result = get_num_hosts_job(spank);
+
+   return result;
+}
+
+static char **get_hostlist_job(spank_t spank, unsigned int num_hosts)
+{
+   char *short_hosts, **hostlist;
+
+   short_hosts = readSpankEnv(spank, "SPINDLE_JOB_NODELIST");
    if (!short_hosts)
       short_hosts = readSpankEnv(spank, "SLURM_JOB_NODELIST");
    if (!short_hosts)
       short_hosts = readSpankEnv(spank, "SLURM_NODELIST");
    if (!short_hosts) {
-      sdprintf(1, "ERROR: None of SLURM_STEP_NODELIST, SLURM_JOB_NODELIST, SLURM_NODELIST set.\n");
+      sdprintf(2, "None of SPINDLE_JOB_NODELIST, SLURM_JOB_NODELIST, or SLURM_NODELIST is set.\n");
       return NULL;
    }   
 
@@ -392,10 +876,44 @@ static char **get_hostlist(spank_t spank, unsigned int num_hosts)
    hostlist = getHostsParse(num_hosts, short_hosts);
 #endif
    free(short_hosts);
+
+   return hostlist;
+}
+
+static char **get_hostlist_step(spank_t spank, unsigned int num_hosts)
+{
+   char *short_hosts, **hostlist;;
+
+   short_hosts = readSpankEnv(spank, "SLURM_STEP_NODELIST");
+   if (!short_hosts) {
+      sdprintf(2, "SLURM_STEP_NODELIST not set.\n");
+      return NULL;
+   }   
+
+#if defined(SCONTROL_BIN)
+   hostlist = getHostsScontrol(num_hosts, short_hosts);
+#else
+   hostlist = getHostsParse(num_hosts, short_hosts);
+#endif
+   free(short_hosts);
+
+   return hostlist;
+}
+
+static char **get_hostlist(spank_t spank, unsigned int num_hosts)
+{
+   char **hostlist;
+
+   hostlist = get_hostlist_step(spank, num_hosts);
+
+   if (!hostlist)
+      hostlist = get_hostlist_job(spank, num_hosts);
+
    if (!hostlist) {
       sdprintf(1, "ERROR: Could not get list of hosts in job.  Aborting spindle\n");
       return NULL;
    }
+
    return hostlist;
 }
 
@@ -469,11 +987,11 @@ static int get_spindle_args(spank_t spank, spindle_args_t *params)
 
 static int launch_spindle(spank_t spank, spindle_args_t *params)
 {
-   char **hostlist = NULL, **hostaddrlist = NULL;
+   char **hostlist = NULL, **hostlist_job = NULL, **hostlist_fe = NULL, **hostaddrlist = NULL;
    int result;
    int is_fe_host = 0;
    int is_be_leader = 0;
-   unsigned int i, num_hosts;
+   unsigned int i, num_hosts, num_hosts_job, num_hosts_fe;
    int num_hosts_result;
    int launch_result = -1;
 
@@ -494,22 +1012,46 @@ static int launch_spindle(spank_t spank, spindle_args_t *params)
    if (is_fe_host == -1) 
       goto done;
 
+
    sdprintf(1, "is_fe_host = %d, is_be_leader = %d\n", (int) is_fe_host, (int) is_be_leader);
    
-   if (is_be_leader) {
+   // Don't launch BE when using rshlaunch; FE will launch BEs
+   if (is_be_leader && !(params->opts & OPT_RSHLAUNCH)) {
       result = launchBE(spank, params);
       if (result == -1)
          goto done;
    }
 
    if (is_fe_host && is_be_leader) {
+      // When starting a session with rshlaunch, we need to start
+      // on all the nodes of the *whole job*, not just the nodes of 
+      // this particular step.
+      if ((params->opts & OPT_RSHLAUNCH) && (params->opts & OPT_SESSION)) {
+          num_hosts_result = get_num_hosts_job(spank);
+          if (num_hosts_result == -1) {
+              slurm_error("ERROR: failed to get num hosts for job");
+              goto done;               
+          }
+          num_hosts_job = (unsigned int) num_hosts_result;
+          hostlist_job = get_hostlist_job(spank, num_hosts_job);
+          if (!hostlist_job) {
+              slurm_error("ERROR: failed to get hosts for job");
+              goto done;
+          }
+          hostlist_fe = hostlist_job;
+          num_hosts_fe = num_hosts_job;
+      } else {
+          // Otherwise, start with the nodes of the step.
+          hostlist_fe = hostlist;
+          num_hosts_fe = num_hosts;
+      }
 #if defined(SINFO_BIN)
-      hostaddrlist = getHostAddrSinfo(num_hosts, hostlist);
+      hostaddrlist = getHostAddrSinfo(num_hosts_fe, hostlist_fe);
       if (!hostaddrlist)
-	  goto done;
+	     goto done;
       result = launchFE(hostaddrlist, params);
 #else
-      result = launchFE(hostlist, params);
+      result = launchFE(hostlist_fe, params);
 #endif
       if (result == -1)
          goto done;
@@ -522,6 +1064,10 @@ static int launch_spindle(spank_t spank, spindle_args_t *params)
       for (i = 0; i < num_hosts; i++) free(hostlist[i]);
       free(hostlist);
    }
+   if (hostlist_job) {
+      for (i = 0; i < num_hosts_job; i++) free(hostlist_job[i]);
+      free(hostlist_job);
+   }
    if (hostaddrlist) {
       for (i = 0; i < num_hosts; i++) free(hostaddrlist[i]);
       free(hostaddrlist);
@@ -530,11 +1076,19 @@ static int launch_spindle(spank_t spank, spindle_args_t *params)
    return launch_result;
 }
 
+/* Handles arguments to srun */
 static int spindle_options(int val, const char *optarg, int remote)
 {
    enable_spindle = 1;
    user_options = optarg;
    
+   return 0;
+}
+
+/* Handles arguments to salloc and sbatch */
+static int spindle_session_options(int val, const char *optarg, int remote)
+{
+   start_session = 1;
    return 0;
 }
 
@@ -565,23 +1119,28 @@ static int launchFE(char **hostlist, spindle_args_t *params)
       exit(-1);
    }
 
-   result = spindleWaitForCloseFE(params);
-   if (result == -1) {
-      sdprintf(1, "ERROR: Could not wait for FE close\n");      
+   if ((params->opts & OPT_SESSION) || (params->opts & OPT_RSHLAUNCH)) {
+      result = waitForSpankSessionEnd(params);
+   } else {
+      result = spindleWaitForCloseFE(params);  
    }
-   
+
+   if (result == -1) {
+       sdprintf(1, "ERROR: Could not wait for FE close\n");      
+   }
+      
    sdprintf(1, "FE received exit signal.  Shutting down FE\n");
    result = spindleCloseFE(params);
    if (result == -1) {
-      sdprintf(1, "ERROR: Could not clean up FE.\n");
-      exit(-1);
+       sdprintf(1, "ERROR: Could not clean up FE.\n");
+       exit(-1);
    }
    exit(0);
 }
 
 static int launchBE(spank_t spank, spindle_args_t *params)
 {
-   int result;
+   int result = 0;
 
    if (pidBE) {
       sdprintf(3, "Spindle BE already running.  Not relaunching\n");
@@ -622,7 +1181,7 @@ static int launchBE(spank_t spank, spindle_args_t *params)
 static int prepApp(spank_t spank, spindle_args_t *params)
 {
 #if HAVE_DECL_SPANK_PREPEND_TASK_ARGV == 1
-   int result;
+   int result, i;
 #else
    int app_argc, result;
    char **app_argv;
@@ -640,6 +1199,10 @@ static int prepApp(spank_t spank, spindle_args_t *params)
       
 #if HAVE_DECL_SPANK_PREPEND_TASK_ARGV == 1
    sdprintf(2, "Prepping task process %d to run spindle using spank_prepend_task_argv method\n", getpid());
+   sdprintf(2, "spank_prepend_task_argv will prepend %d args\n", bootstrap_argc);
+   for(i = 0; i < bootstrap_argc; ++i) {
+      sdprintf(2, "bootstrap_argv[%d] = %s\n", i, bootstrap_argv[i]);
+   }
 
    const char **filter_argv = (const char **)bootstrap_argv;
    err = spank_prepend_task_argv(spank, bootstrap_argc, filter_argv);
@@ -675,9 +1238,11 @@ static int handleExit(void *params, char **output_str)
 {
    exit_params_t *exit_params;
    spank_t spank;
-   int site_argc, result, is_be_leader;
-   char **site_argv;
+   int site_argc, result, is_be_leader, is_fe_host, use_session, num_hosts_result;
+   unsigned int num_hosts;
+   char **site_argv, **hostlist;
    spindle_args_t args = {0};
+   int launch_result = -1;
 
    exit_params = (exit_params_t *) params;
    spank = exit_params->spank;
@@ -685,7 +1250,8 @@ static int handleExit(void *params, char **output_str)
    site_argv = exit_params->site_argv;
 
    sdprintf(1, "In handleExit\n");
-   result = process_spindle_args(spank, site_argc, site_argv, &args, NULL, NULL);
+   use_session = should_use_session(spank);
+   result = process_spindle_args(spank, site_argc, site_argv, &args, NULL, NULL, use_session);
    if (result == -1) {
       sdprintf(1, "ERROR: Could not process spindle args in handleExit\n");
       return -1;
@@ -701,11 +1267,23 @@ static int handleExit(void *params, char **output_str)
       // The task_exit callback is run for _each proc_, so we use
       // isBEProc to pick only one proc per node to call spindleExitBE.
       is_be_leader = isBEProc(&args, 1);
-      if (is_be_leader) {
-         result = spindleExitBE(args.location);
-         if (result == -1) {
-             sdprintf(1, "ERROR: spindleExitBE returned an error on location %s\n", args.location);
-             return -1;
+      if (is_be_leader) { 
+         if (use_session || (args.opts & OPT_RSHLAUNCH)) {
+            result = signalSpankSessionEnd(&args); 
+            if (result == -1) {
+               // We don't count a failure to signal the session end as
+               // a failure here because we get the exit callback on
+               // every node, even if the prolog never ran.
+               // So there might not even be a session to end.
+               sdprintf(2, "No session FE running on host"); 
+               return 0;
+            }
+         } else {
+            result = spindleExitBE(args.location);
+            if (result == -1) {
+                sdprintf(1, "ERROR: spindleExitBE returned an error on location %s\n", args.location);
+                return -1;
+            }
          }
       }
    }

--- a/testsuite/runTests_template
+++ b/testsuite/runTests_template
@@ -6,6 +6,16 @@ export TEST_RM="TEST_RESOURCE_MANAGER"
 export GLOBAL_RESULT=0
 CHECK_RETCODE() { if [[ $? != 0 ]]; then export GLOBAL_RESULT=-1; fi }
 
+# For slurm-plugin, whether we use a session is determined by the allocation we run in.
+# Run only the non-session tests if this allocation doesn't use a session.
+# Run only the session tests if this allocation uses a session.
+SKIP_NONSESSION=false
+if test "x$TEST_RM" == "xslurm-plugin" && test "x$SPANK_SPINDLE_USE_SESSION" != "x"; then
+    SKIP_NONSESSION=true
+fi
+
+if test "x$SKIP_NONSESSION" != "xtrue"; then
+
 ./run_driver --dependency --push
 CHECK_RETCODE
 ./run_driver --dlopen --push
@@ -129,7 +139,17 @@ CHECK_RETCODE
 ./run_driver --spindleapi --preload
 CHECK_RETCODE
 
-if test "x$TEST_RM" != "xserial"; then
+fi # SKIP_NONSESSION
+
+SKIP_SESSION=false
+if test "x$TEST_RM" == "xserial"; then
+    SKIP_SESSION=true
+fi
+if test "x$TEST_RM" == "xslurm-plugin" && test "x$SPANK_SPINDLE_USE_SESSION" == "x"; then
+    SKIP_SESSION=true
+fi
+
+if test "x$SKIP_SESSION" != "xtrue"; then
 export SESSION_ID=`./run_driver --start-session`
 ./run_driver --dependency --session
 CHECK_RETCODE

--- a/testsuite/run_driver_template
+++ b/testsuite/run_driver_template
@@ -11,6 +11,10 @@ export SPINDLE=SPINDLE_EXEC
 export PATH=$PATH:.
 
 if [ $1 == --start-session ] ; then
+    # With SPANK plugin, sessions are started by argument to salloc/sbatch instead
+    if [ "x$TEST_RM" == "xslurm-plugin" ] ; then
+        exit 0
+    fi
     export SPINDLEID=`$SPINDLE --start-session --level=high`
     if [ x$SPINDLEID == x ]; then
         echo ANONYMOUS_SESSION
@@ -20,6 +24,9 @@ if [ $1 == --start-session ] ; then
     exit 0
 fi
 if [ $1 == --end-session ] ; then
+    if [ "x$TEST_RM" == "xslurm-plugin" ] ; then
+        exit 0
+    fi
     if [ x$2 == xANONYMOUS_SESSION ] ; then
         $SPINDLE --end-session
     else
@@ -59,11 +66,14 @@ export SPINDLE_OPTS="--numa"
 fi
 
 if [ $2 == --session ] ; then
-  if [ x$SESSION_ID == x ] ; then
-    export SESSION_ID=`$SPINDLE --start-session`
-    export STARTED_SPINDLE_SESSION=true
+  # With SPANK plugin, we run in session if the allocation has a session
+  if [ "x$TEST_RM" != "xslurm-plugin" ] ; then
+    if [ x$SESSION_ID == x ] ; then
+      export SESSION_ID=`$SPINDLE --start-session`
+      export STARTED_SPINDLE_SESSION=true
+    fi
+    export SPINDLE_OPTS="--run-in-session $SESSION_ID"
   fi
-  export SPINDLE_OPTS="--run-in-session $SESSION_ID"
 fi
 
 export SPINDLE_BLUEGENE="BLUEGENE_TEST"


### PR DESCRIPTION
Adds support for sessions to the SPANK plugin.

To ensure that sessions end when the allocation does, sessions are made part of the allocation. An allocation uses a session by passing `--spindle-session` as an argument to `salloc` or `sbatch`. This differs from the other launchers which use `spindle --start-session`: the session is automatically started when the first step runs, and is automatically ended when the allocation ends.

The major complication is that we have to start the session on every node of the job, even if the first step doesn't run on every node. When using rshlaunch, the first step uses rshlaunch to start the session on every node of the job. When not using rshlaunch, we have to use a dummy `srun` on every node to cause the job prolog to run everywhere. The srun runs `/bin/true` and so exits immediately, not consuming any resources. However, this has the side effect of using up a step ID. This could interfere with job scripts that assume the step IDs instead of checking. For this reason, the rshlaunch configuration may be preferred.

To signal session end, a Unix socket is used. This is very similar to, and adapted from, the code used for the "exit note" with `OPT_BEEXIT`.

Almost all of the changes are restricted to the SPANK plugin itself. The only changes outside the SPANK plugin are to the testsuite: because the sessions are allocation-scoped, session and non-session tests must run in two different allocations. When the resource manager is `slurm_plugin`, the test scripts check whether a session is being used in the current allocation and run either the session or non-session tests accordingly. The CI workflow for the plugin tests runs `./runTests` twice, once outside a session and once inside.