### PR TITLE
Cleans up three warnings via -W[all|extra|error].

### DIFF
--- a/src/client/beboot/spindle_bootstrap.c
+++ b/src/client/beboot/spindle_bootstrap.c
@@ -148,6 +148,7 @@ static int setup_environment()
          free(preload);
       }
    }
+   return 0;
 }
 
 static int parse_cmdline(int argc, char *argv[])

--- a/src/client/client/intercept_readlink.c
+++ b/src/client/client/intercept_readlink.c
@@ -27,6 +27,7 @@ Place, Suite 330, Boston, MA 02111-1307 USA
 #include "client_api.h"
 #include "spindle_launch.h"
 #include "should_intercept.h"
+#include "ccwarns.h"
 
 ssize_t (*orig_readlink)(const char *path, char *buf, size_t bufsiz);
 ssize_t (*orig_readlinkat)(int dirfd, const char *pathname, char *buf, size_t bufsiz);
@@ -114,8 +115,10 @@ ssize_t readlink_wrapper(const char *path, char *buf, size_t bufsiz)
    }
 
    len = strlen(resultpath);
+GCC7_DISABLE_WARNING("-Wsign-compare");
    if (len > bufsiz)
       len = bufsiz;
+GCC7_ENABLE_WARNING;
    memcpy(buf, resultpath, len);
    debug_printf2("spindle readlink translated %s to %.*s with len %zu\n", path, (int)len, buf, len);
    return len;

--- a/src/server/auditserver/cleanup_proc.cc
+++ b/src/server/auditserver/cleanup_proc.cc
@@ -56,7 +56,8 @@ static void rmDirSet(const set<string> &dirs, const char *cachepath, const char 
    string path_sep("/");
    if( !cachepath || !commpath ){
        // Should never happen.
-       err_printf( "cachepath (%s) and/or commpath (%s) is NULL.  Unable to cleanup files.\n" );
+       err_printf( "cachepath (%s) and/or commpath (%s) is NULL.  Unable to cleanup files.\n",
+              cachepath, commpath );
        return;
    }
    size_t cachepath_len = strlen(cachepath);


### PR DESCRIPTION
Fixes #189.